### PR TITLE
Integrations declare themselves to the registry

### DIFF
--- a/CriteoPublisherSdk/CriteoPublisherSdk.xcodeproj/project.pbxproj
+++ b/CriteoPublisherSdk/CriteoPublisherSdk.xcodeproj/project.pbxproj
@@ -255,6 +255,7 @@
 		C07AB927256BB7EE061C89EA /* CRMediaView+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = C07AB967F5DA5C6504960784 /* CRMediaView+Internal.h */; };
 		C07AB936F1DBBE6CC8C2644E /* CRMediaContent.m in Sources */ = {isa = PBXBuildFile; fileRef = C07ABD4814092221709B77BA /* CRMediaContent.m */; };
 		C07AB96240CAD13D1FC39753 /* CR_ImageCache.h in Headers */ = {isa = PBXBuildFile; fileRef = C07ABDA25C65E3BBAAF68A79 /* CR_ImageCache.h */; };
+		C07AB98B6BF9878FBBD190FF /* CriteoTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C07ABBFC2256322A8A934EF7 /* CriteoTests.m */; };
 		C07AB9ED69EB74DA88306686 /* CR_FeedbackFeatureGuard.m in Sources */ = {isa = PBXBuildFile; fileRef = C07AB7277BC095D4A7DF86E2 /* CR_FeedbackFeatureGuard.m */; };
 		C07AB9F7F2A6BB33242A47D5 /* CR_DisplaySizeInjectorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C07AB4BAE67CF9EC778F3E5C /* CR_DisplaySizeInjectorTests.m */; };
 		C07ABA93B122BDB3E135E36C /* CR_IntegrationRegistryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C07AB56CA043C8013EC0F611 /* CR_IntegrationRegistryTests.m */; };
@@ -624,6 +625,7 @@
 		C07ABB7F084CBEDAC1960E3C /* CR_DefaultMediaDownloaderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CR_DefaultMediaDownloaderTests.m; sourceTree = "<group>"; };
 		C07ABBA46FCA43B62B82A2A0 /* CR_FeedbackControllerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CR_FeedbackControllerTests.m; sourceTree = "<group>"; };
 		C07ABBC696D95F756547DA86 /* CR_NativeAssets+Testing.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "CR_NativeAssets+Testing.m"; path = "Native/CR_NativeAssets+Testing.m"; sourceTree = "<group>"; };
+		C07ABBFC2256322A8A934EF7 /* CriteoTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CriteoTests.m; sourceTree = "<group>"; };
 		C07ABC983FB1DA60294D238A /* CR_FeedbackController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CR_FeedbackController.m; sourceTree = "<group>"; };
 		C07ABCED19D15ED05D88A0E9 /* image.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = image.png; sourceTree = "<group>"; };
 		C07ABCFF5BBAF82978CD2E45 /* CR_RemoteConfigRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CR_RemoteConfigRequest.h; sourceTree = "<group>"; };
@@ -1000,6 +1002,7 @@
 				7D58583323E2D5AD0039AC56 /* Threading */,
 				7D3E41FF23915B6600BAF673 /* Util */,
 				C07AB4BAE67CF9EC778F3E5C /* CR_DisplaySizeInjectorTests.m */,
+				C07ABBFC2256322A8A934EF7 /* CriteoTests.m */,
 			);
 			path = UnitTests;
 			sourceTree = "<group>";
@@ -1902,6 +1905,7 @@
 				C07AB22678B6CBC62B23F559 /* UIImage+Testing.m in Sources */,
 				C07AB9F7F2A6BB33242A47D5 /* CR_DisplaySizeInjectorTests.m in Sources */,
 				C07ABD165AFA5B3044B8AAD3 /* CR_RemoteConfigRequestTests.m in Sources */,
+				C07AB98B6BF9878FBBD190FF /* CriteoTests.m in Sources */,
 				C07ABA93B122BDB3E135E36C /* CR_IntegrationRegistryTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/CriteoPublisherSdk/Sources/CR_DependencyProvider.m
+++ b/CriteoPublisherSdk/Sources/CR_DependencyProvider.m
@@ -116,7 +116,8 @@
 - (CR_HeaderBidding *)headerBidding {
   return CR_LAZY(_headerBidding,
                  [[CR_HeaderBidding alloc] initWithDevice:self.deviceInfo
-                                      displaySizeInjector:self.displaySizeInjector]);
+                                      displaySizeInjector:self.displaySizeInjector
+                                      integrationRegistry:self.integrationRegistry]);
 }
 
 - (CR_DisplaySizeInjector *)displaySizeInjector {

--- a/CriteoPublisherSdk/Sources/CR_HeaderBidding.h
+++ b/CriteoPublisherSdk/Sources/CR_HeaderBidding.h
@@ -25,6 +25,7 @@
 @class CR_CdbBid;
 @class CR_CacheAdUnit;
 @class CR_DisplaySizeInjector;
+@class CR_IntegrationRegistry;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -38,6 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithDevice:(id<CR_HeaderBiddingDevice>)device
            displaySizeInjector:(CR_DisplaySizeInjector *)displaySizeInjector
+           integrationRegistry:(CR_IntegrationRegistry *)integrationRegistry
     NS_DESIGNATED_INITIALIZER;
 
 /**

--- a/CriteoPublisherSdk/Sources/Criteo.m
+++ b/CriteoPublisherSdk/Sources/Criteo.m
@@ -24,6 +24,7 @@
 #import "CR_ThreadManager.h"
 #import "Logging.h"
 #import "CR_DependencyProvider.h"
+#import "CR_IntegrationRegistry.h"
 
 @interface Criteo ()
 
@@ -128,6 +129,7 @@
 }
 
 - (CRBidResponse *)getBidResponseForAdUnit:(CRAdUnit *)adUnit {
+  [self.integrationRegistry declare:CR_IntegrationInHouse];
   return [self.bidManager bidResponseForCacheAdUnit:[CR_AdUnitHelper cacheAdUnitForAdUnit:adUnit]
                                          adUnitType:adUnit.adUnitType];
 }
@@ -147,6 +149,10 @@
 
 - (CR_ThreadManager *)threadManager {
   return self.dependencyProvider.threadManager;
+}
+
+- (CR_IntegrationRegistry *)integrationRegistry {
+  return self.dependencyProvider.integrationRegistry;
 }
 
 @end

--- a/CriteoPublisherSdk/Sources/Native/CRNativeLoader.m
+++ b/CriteoPublisherSdk/Sources/Native/CRNativeLoader.m
@@ -36,6 +36,7 @@
 #import "CR_URLOpening.h"
 #import "CR_DependencyProvider.h"
 #import "CR_NetworkManager.h"
+#import "CR_IntegrationRegistry.h"
 
 @implementation CRNativeLoader
 
@@ -132,6 +133,8 @@
 }
 
 - (void)unsafeLoadAd {
+  [self.integrationRegistry declare:CR_IntegrationStandalone];
+
   if (!self.canConsumeBid) {
     return;
   }
@@ -172,6 +175,10 @@
 
 - (CR_ThreadManager *)threadManager {
   return self.criteo.dependencyProvider.threadManager;
+}
+
+- (CR_IntegrationRegistry *)integrationRegistry {
+  return self.criteo.dependencyProvider.integrationRegistry;
 }
 
 #pragma mark - Delegate call

--- a/CriteoPublisherSdk/Sources/Standalone/CRBannerView.m
+++ b/CriteoPublisherSdk/Sources/Standalone/CRBannerView.m
@@ -26,6 +26,8 @@
 #import "CR_TokenValue.h"
 #import "NSURL+Criteo.h"
 #import "CR_URLOpening.h"
+#import "CR_IntegrationRegistry.h"
+#import "CR_DependencyProvider.h"
 
 // TODO check import strategy
 @import WebKit;
@@ -101,6 +103,8 @@
 }
 
 - (void)loadAd {
+  [self.integrationRegistry declare:CR_IntegrationStandalone];
+
   self.isResponseValid = NO;
   CR_CacheAdUnit *cacheAdUnit = [[CR_CacheAdUnit alloc] initWithAdUnitId:_adUnit.adUnitId
                                                                     size:self.frame.size
@@ -226,6 +230,10 @@
       [self.delegate banner:self didFailToReceiveAdWithError:error];
     }
   });
+}
+
+- (CR_IntegrationRegistry *)integrationRegistry {
+  return self.criteo.dependencyProvider.integrationRegistry;
 }
 
 @end

--- a/CriteoPublisherSdk/Sources/Standalone/CRInterstitial.m
+++ b/CriteoPublisherSdk/Sources/Standalone/CRInterstitial.m
@@ -30,6 +30,7 @@
 #import "CR_URLOpening.h"
 #import "CR_DependencyProvider.h"
 #import "CR_DisplaySizeInjector.h"
+#import "CR_IntegrationRegistry.h"
 
 @import WebKit;
 
@@ -98,6 +99,8 @@
 }
 
 - (void)loadAd {
+  [self.integrationRegistry declare:CR_IntegrationStandalone];
+
   if (![self checkSafeToLoad]) {
     return;
   }
@@ -331,6 +334,10 @@
 
 - (CR_DisplaySizeInjector *)displaySizeInjector {
   return _criteo.dependencyProvider.displaySizeInjector;
+}
+
+- (CR_IntegrationRegistry *)integrationRegistry {
+  return _criteo.dependencyProvider.integrationRegistry;
 }
 
 @end

--- a/CriteoPublisherSdk/Tests/IntegrationTests/CRBannerViewDelegateTests.m
+++ b/CriteoPublisherSdk/Tests/IntegrationTests/CRBannerViewDelegateTests.m
@@ -34,41 +34,35 @@
 #import "XCTestCase+Criteo.h"
 #import "NSURL+Criteo.h"
 #import "CR_TokenValue+Testing.h"
+#import "CR_DependencyProvider.h"
+#import "CR_DependencyProvider+Testing.h"
 
 @interface CRBannerViewDelegateTests : XCTestCase {
-  CR_CacheAdUnit *cacheAdUnit;
-  CRBannerAdUnit *adUnit;
-  CR_CdbBid *bid;
   WKNavigationResponse *validNavigationResponse;
 }
 
+@property(nonatomic, strong) CR_CacheAdUnit *expectedCacheAdUnit;
+@property(nonatomic, strong) CRBannerAdUnit *adUnit;
 @property(strong, nonatomic) CR_URLOpenerMock *urlOpener;
+@property(strong, nonatomic) Criteo *criteo;
+@property(strong, nonatomic) CRBannerViewDelegateMock *delegate;
 
 @end
 
 @implementation CRBannerViewDelegateTests
 
 - (void)setUp {
-  bid = nil;
-  cacheAdUnit = nil;
-  adUnit = nil;
+  self.expectedCacheAdUnit = [[CR_CacheAdUnit alloc] initWithAdUnitId:@"123"
+                                                                 size:CGSizeMake(47.0f, 57.0f)
+                                                           adUnitType:CRAdUnitTypeBanner];
+  self.adUnit = [[CRBannerAdUnit alloc] initWithAdUnitId:@"123" size:CGSizeMake(47.0f, 57.0f)];
+
   self.urlOpener = [[CR_URLOpenerMock alloc] init];
-}
 
-- (CR_CacheAdUnit *)expectedAdUnit {
-  if (!cacheAdUnit) {
-    cacheAdUnit = [[CR_CacheAdUnit alloc] initWithAdUnitId:@"123"
-                                                      size:CGSizeMake(47.0f, 57.0f)
-                                                adUnitType:CRAdUnitTypeBanner];
-  }
-  return cacheAdUnit;
-}
+  CR_DependencyProvider *dependencyProvider = CR_DependencyProvider.testing_dependencyProvider;
+  self.criteo = OCMPartialMock([Criteo.alloc initWithDependencyProvider:dependencyProvider]);
 
-- (CRBannerAdUnit *)adUnit {
-  if (!adUnit) {
-    adUnit = [[CRBannerAdUnit alloc] initWithAdUnitId:@"123" size:CGSizeMake(47.0f, 57.0f)];
-  }
-  return adUnit;
+  self.delegate = [[CRBannerViewDelegateMock alloc] init];
 }
 
 - (WKNavigationResponse *)validNavigationResponse {
@@ -82,76 +76,46 @@
 }
 
 - (CR_CdbBid *)bidWithDisplayURL:(NSString *)displayURL {
-  if (!bid) {
-    bid = [[CR_CdbBid alloc] initWithZoneId:@123
-                                placementId:@"placementId"
-                                        cpm:@"4.2"
-                                   currency:@"₹😀"
-                                      width:@47.0f
-                                     height:[NSNumber numberWithFloat:57.0f]
-                                        ttl:26
-                                   creative:@"THIS IS USELESS LEGACY"
-                                 displayUrl:displayURL
-                                 insertTime:[NSDate date]
-                               nativeAssets:nil
-                               impressionId:nil];
-  }
-  return bid;
+  return [[CR_CdbBid alloc] initWithZoneId:@123
+                               placementId:@"placementId"
+                                       cpm:@"4.2"
+                                  currency:@"₹😀"
+                                     width:@47.0f
+                                    height:@57.0f
+                                       ttl:26
+                                  creative:@"THIS IS USELESS LEGACY"
+                                displayUrl:displayURL
+                                insertTime:[NSDate date]
+                              nativeAssets:nil
+                              impressionId:nil];
 }
 
 - (void)testBannerDidReceiveAd {
   WKWebView *realWebView = [WKWebView new];
-  Criteo *mockCriteo = OCMStrictClassMock([Criteo class]);
-  OCMStub(mockCriteo.config).andReturn([[CR_Config alloc] initWithCriteoPublisherId:@"123"]);
-  OCMStub([mockCriteo getBid:[self expectedAdUnit]]).andReturn([self bidWithDisplayURL:@"test"]);
-  CRBannerView *bannerView =
-      [[CRBannerView alloc] initWithFrame:CGRectMake(13.0f, 17.0f, 47.0f, 57.0f)
-                                   criteo:mockCriteo
-                                  webView:realWebView
-                                   adUnit:self.adUnit
-                                urlOpener:self.urlOpener];
+  OCMStub([self.criteo getBid:[self expectedCacheAdUnit]])
+      .andReturn([self bidWithDisplayURL:@"test"]);
 
-  CRBannerViewDelegateMock *delegate = [[CRBannerViewDelegateMock alloc] init];
-  bannerView.delegate = delegate;
-
+  CRBannerView *bannerView = [self bannerViewWithWebView:realWebView];
+  bannerView.delegate = self.delegate;
   [bannerView loadAd];
 
-  [self cr_waitShortlyForExpectations:@[ delegate.didReceiveAdExpectation ]];
+  [self cr_waitShortlyForExpectations:@[ self.delegate.didReceiveAdExpectation ]];
 }
 
 // test banner fail when an empty bid is returned
 - (void)testBannerAdFetchFail {
-  Criteo *mockCriteo = OCMStrictClassMock([Criteo class]);
-  CRBannerView *bannerView =
-      [[CRBannerView alloc] initWithFrame:CGRectMake(13.0f, 17.0f, 47.0f, 57.0f)
-                                   criteo:mockCriteo
-                                  webView:nil
-                                   adUnit:self.adUnit
-                                urlOpener:self.urlOpener];
+  self.delegate.expectedError = [NSError cr_errorWithCode:CRErrorCodeNoFill];
 
-  CRBannerViewDelegateMock *delegate = [[CRBannerViewDelegateMock alloc] init];
-  delegate.expectedError = [NSError cr_errorWithCode:CRErrorCodeNoFill];
-  bannerView.delegate = delegate;
-  CR_CacheAdUnit *expectedAdUnit = [[CR_CacheAdUnit alloc] initWithAdUnitId:@"123"
-                                                                       size:CGSizeMake(47.0f, 57.0f)
-                                                                 adUnitType:CRAdUnitTypeBanner];
-  OCMStub([mockCriteo getBid:expectedAdUnit]).andReturn([CR_CdbBid emptyBid]);
+  OCMStub([self.criteo getBid:self.expectedCacheAdUnit]).andReturn([CR_CdbBid emptyBid]);
 
+  CRBannerView *bannerView = [self bannerViewWithWebView:nil];
+  bannerView.delegate = self.delegate;
   [bannerView loadAd];
 
-  [self cr_waitShortlyForExpectations:@[ delegate.didFailToReceiveAdWithErrorExpectation ]];
+  [self cr_waitShortlyForExpectations:@[ self.delegate.didFailToReceiveAdWithErrorExpectation ]];
 }
 
 - (void)testBannerWillLeaveApplicationAndWasClicked {
-  CRBannerView *bannerView =
-      [[CRBannerView alloc] initWithFrame:CGRectMake(13.0f, 17.0f, 47.0f, 57.0f)
-                                   criteo:nil
-                                  webView:nil
-                                   adUnit:self.adUnit
-                                urlOpener:self.urlOpener];
-  CRBannerViewDelegateMock *delegate = [[CRBannerViewDelegateMock alloc] init];
-  bannerView.delegate = delegate;
-
   WKNavigationAction *mockNavigationAction = OCMStrictClassMock([WKNavigationAction class]);
   OCMStub(mockNavigationAction.navigationType).andReturn(WKNavigationTypeLinkActivated);
   WKFrameInfo *mockFrame = OCMStrictClassMock([WKFrameInfo class]);
@@ -161,173 +125,126 @@
   NSURLRequest *request = [[NSURLRequest alloc] initWithURL:url];
   OCMStub(mockNavigationAction.request).andReturn(request);
 
+  CRBannerView *bannerView = [self bannerViewWithWebView:nil];
+  bannerView.delegate = self.delegate;
   [bannerView webView:nil
       decidePolicyForNavigationAction:mockNavigationAction
                       decisionHandler:^(WKNavigationActionPolicy decisionHandler){
                       }];
 
   [self cr_waitShortlyForExpectations:@[
-    delegate.wasClickedExpectation, delegate.willLeaveApplicationExpectation
+    self.delegate.wasClickedExpectation, self.delegate.willLeaveApplicationExpectation
   ]];
 }
 
 // test no delegate method called when webView navigation fails
 - (void)testNoDelegateWhenWebViewFailsToNavigate {
-  CRBannerView *bannerView =
-      [[CRBannerView alloc] initWithFrame:CGRectMake(13.0f, 17.0f, 47.0f, 57.0f)
-                                   criteo:nil
-                                  webView:nil
-                                   adUnit:self.adUnit
-                                urlOpener:self.urlOpener];
-  CRBannerViewDelegateMock *delegate = [[CRBannerViewDelegateMock alloc] init];
-  [delegate invertAllExpectations];
-  bannerView.delegate = delegate;
+  [self.delegate invertAllExpectations];
 
+  CRBannerView *bannerView = [self bannerViewWithWebView:nil];
+  bannerView.delegate = self.delegate;
   [bannerView webView:nil didFailNavigation:nil withError:nil];
 
-  [self cr_waitShortlyForExpectations:delegate.allExpectations];
+  [self cr_waitShortlyForExpectations:self.delegate.allExpectations];
 }
 
 // test no delegate method called when webView load fails
 - (void)testNoDelegateWhenWebViewFailsToLoad {
-  CRBannerView *bannerView =
-      [[CRBannerView alloc] initWithFrame:CGRectMake(13.0f, 17.0f, 47.0f, 57.0f)
-                                   criteo:nil
-                                  webView:nil
-                                   adUnit:self.adUnit
-                                urlOpener:self.urlOpener];
+  [self.delegate invertAllExpectations];
 
-  CRBannerViewDelegateMock *delegate = [[CRBannerViewDelegateMock alloc] init];
-  [delegate invertAllExpectations];
-  bannerView.delegate = delegate;
-
+  CRBannerView *bannerView = [self bannerViewWithWebView:nil];
+  bannerView.delegate = self.delegate;
   [bannerView webView:nil didFailProvisionalNavigation:nil withError:nil];
 
-  [self cr_waitShortlyForExpectations:delegate.allExpectations];
+  [self cr_waitShortlyForExpectations:self.delegate.allExpectations];
 }
 
 // test no delegate method called when HTTP error
 - (void)testNoDelegateWhenHTTPError {
-  CRBannerView *bannerView =
-      [[CRBannerView alloc] initWithFrame:CGRectMake(13.0f, 17.0f, 47.0f, 57.0f)
-                                   criteo:nil
-                                  webView:nil
-                                   adUnit:self.adUnit
-                                urlOpener:self.urlOpener];
-
-  CRBannerViewDelegateMock *delegate = [[CRBannerViewDelegateMock alloc] init];
-  [delegate invertAllExpectations];
-  bannerView.delegate = delegate;
+  [self.delegate invertAllExpectations];
 
   WKNavigationResponse *navigationResponse = OCMStrictClassMock([WKNavigationResponse class]);
   NSHTTPURLResponse *response = OCMStrictClassMock([NSHTTPURLResponse class]);
   OCMStub(response.statusCode).andReturn(404);
   OCMStub(navigationResponse.response).andReturn(response);
+
+  CRBannerView *bannerView = [self bannerViewWithWebView:nil];
+  bannerView.delegate = self.delegate;
   [bannerView webView:nil
       decidePolicyForNavigationResponse:navigationResponse
                         decisionHandler:^(WKNavigationResponsePolicy decisionHandler){
                         }];
 
-  [self cr_waitShortlyForExpectations:delegate.allExpectations];
+  [self cr_waitShortlyForExpectations:self.delegate.allExpectations];
 }
 
 - (void)testNoDelegateWhenNoHttpResponse {
   WKWebView *realWebView = [WKWebView new];
-  Criteo *mockCriteo = OCMStrictClassMock([Criteo class]);
-  OCMStub(mockCriteo.config).andReturn([[CR_Config alloc] initWithCriteoPublisherId:@"123"]);
-  CRBannerView *bannerView =
-      [[CRBannerView alloc] initWithFrame:CGRectMake(13.0f, 17.0f, 47.0f, 57.0f)
-                                   criteo:mockCriteo
-                                  webView:realWebView
-                                   adUnit:self.adUnit
-                                urlOpener:self.urlOpener];
 
-  CRBannerViewDelegateMock *delegate = [[CRBannerViewDelegateMock alloc] init];
-  bannerView.delegate = delegate;
+  OCMStub([self.criteo getBid:[self expectedCacheAdUnit]]).andReturn([self bidWithDisplayURL:@""]);
 
-  OCMStub([mockCriteo getBid:[self expectedAdUnit]]).andReturn([self bidWithDisplayURL:@""]);
+  CRBannerView *bannerView = [self bannerViewWithWebView:realWebView];
+  bannerView.delegate = self.delegate;
   [bannerView loadAd];
-  [self cr_waitShortlyForExpectations:@[ delegate.didReceiveAdExpectation ]];
+
+  [self cr_waitShortlyForExpectations:@[ self.delegate.didReceiveAdExpectation ]];
 }
 
 #pragma mark inhouseSpecificTests
 
 - (void)testBannerLoadFailWhenTokenValueIsNil {
-  Criteo *mockCriteo = OCMStrictClassMock([Criteo class]);
   WKWebView *mockWebView = [WKWebView new];
-  CRBannerAdUnit *adUnit = [[CRBannerAdUnit alloc] initWithAdUnitId:@"Yup"
-                                                               size:CGSizeMake(200, 200)];
-  CRBannerView *bannerView =
-      [[CRBannerView alloc] initWithFrame:CGRectMake(13.0f, 17.0f, 47.0f, 57.0f)
-                                   criteo:mockCriteo
-                                  webView:mockWebView
-                                   adUnit:adUnit
-                                urlOpener:self.urlOpener];
+  CRBannerView *bannerView = [self bannerViewWithWebView:mockWebView];
   CRBidToken *token = [[CRBidToken alloc] initWithUUID:[NSUUID UUID]];
-  OCMStub([mockCriteo tokenValueForBidToken:token adUnitType:CRAdUnitTypeBanner]).andReturn(nil);
+  OCMStub([self.criteo tokenValueForBidToken:token adUnitType:CRAdUnitTypeBanner]).andReturn(nil);
   id<CRBannerViewDelegate> mockBannerViewDelegate =
       OCMStrictProtocolMock(@protocol(CRBannerViewDelegate));
   bannerView.delegate = mockBannerViewDelegate;
   OCMStub([mockBannerViewDelegate banner:bannerView didFailToReceiveAdWithError:[OCMArg any]]);
   [bannerView loadAdWithBidToken:token];
 
-  CRBannerViewDelegateMock *delegate = [[CRBannerViewDelegateMock alloc] init];
-  delegate.expectedError = [NSError cr_errorWithCode:CRErrorCodeNoFill];
-  bannerView.delegate = delegate;
+  self.delegate.expectedError = [NSError cr_errorWithCode:CRErrorCodeNoFill];
+  bannerView.delegate = self.delegate;
 
   [bannerView loadAdWithBidToken:token];
 
-  [self cr_waitForExpectations:@[ delegate.didFailToReceiveAdWithErrorExpectation ]];
+  [self cr_waitForExpectations:@[ self.delegate.didFailToReceiveAdWithErrorExpectation ]];
 }
 
 - (void)testBannerLoadFailWhenTokenValueDoesntMatchAdUnitId {
-  Criteo *mockCriteo = OCMStrictClassMock([Criteo class]);
   WKWebView *mockWebView = [WKWebView new];
-  CRBannerAdUnit *adUnit1 = [[CRBannerAdUnit alloc] initWithAdUnitId:@"Yup"
-                                                                size:CGSizeMake(200, 200)];
-  CRBannerAdUnit *adUnit2 = [[CRBannerAdUnit alloc] initWithAdUnitId:@"Yo"
-                                                                size:CGSizeMake(200, 200)];
-  CRBannerView *bannerView =
-      [[CRBannerView alloc] initWithFrame:CGRectMake(13.0f, 17.0f, 47.0f, 57.0f)
-                                   criteo:mockCriteo
-                                  webView:mockWebView
-                                   adUnit:adUnit1
-                                urlOpener:self.urlOpener];
+
+  CRBannerAdUnit *wrongAdUnit = [[CRBannerAdUnit alloc] initWithAdUnitId:@"Yo"
+                                                                    size:CGSizeMake(200, 200)];
+
   CRBidToken *token = [[CRBidToken alloc] initWithUUID:[NSUUID UUID]];
   CR_TokenValue *expectedTokenValue = [CR_TokenValue tokenValueWithDisplayUrl:@"test"
-                                                                       adUnit:adUnit2];
-  ;
-  OCMStub([mockCriteo tokenValueForBidToken:token adUnitType:CRAdUnitTypeBanner])
+                                                                       adUnit:wrongAdUnit];
+
+  OCMStub([self.criteo tokenValueForBidToken:token adUnitType:CRAdUnitTypeBanner])
       .andReturn(expectedTokenValue);
 
-  CRBannerViewDelegateMock *delegate = [[CRBannerViewDelegateMock alloc] init];
-  delegate.expectedError = [NSError
+  self.delegate.expectedError = [NSError
       cr_errorWithCode:CRErrorCodeInvalidParameter
            description:
                @"Token passed to loadAdWithBidToken doesn't have the same ad unit as the CRBannerView was initialized with"];
-  bannerView.delegate = delegate;
 
+  CRBannerView *bannerView = [self bannerViewWithWebView:mockWebView];
+  bannerView.delegate = self.delegate;
   [bannerView loadAdWithBidToken:token];
 
-  [self cr_waitForExpectations:@[ delegate.didFailToReceiveAdWithErrorExpectation ]];
+  [self cr_waitForExpectations:@[ self.delegate.didFailToReceiveAdWithErrorExpectation ]];
 }
 
 - (void)testBannerLoadFailWhenTokenValueDoesntMatchAdUnitType {
-  Criteo *mockCriteo = OCMStrictClassMock([Criteo class]);
   WKWebView *mockWebView = [WKWebView new];
-  CRBannerAdUnit *adUnit1 = [[CRBannerAdUnit alloc] initWithAdUnitId:@"Yup"
-                                                                size:CGSizeMake(200, 200)];
-  CRInterstitialAdUnit *adUnit2 = [[CRInterstitialAdUnit alloc] initWithAdUnitId:@"Yo"];
-  CRBannerView *bannerView =
-      [[CRBannerView alloc] initWithFrame:CGRectMake(13.0f, 17.0f, 47.0f, 57.0f)
-                                   criteo:mockCriteo
-                                  webView:mockWebView
-                                   adUnit:adUnit1
-                                urlOpener:self.urlOpener];
+
+  CRInterstitialAdUnit *wrongAdUnit = [[CRInterstitialAdUnit alloc] initWithAdUnitId:@"Yo"];
+  CRBannerView *bannerView = [self bannerViewWithWebView:mockWebView];
   CRBidToken *token = [[CRBidToken alloc] initWithUUID:[NSUUID UUID]];
   CR_TokenValue *expectedTokenValue = [CR_TokenValue tokenValueWithDisplayUrl:@"test"
-                                                                       adUnit:adUnit2];
-  OCMStub([mockCriteo tokenValueForBidToken:token adUnitType:CRAdUnitTypeBanner])
+                                                                       adUnit:wrongAdUnit];
+  OCMStub([self.criteo tokenValueForBidToken:token adUnitType:CRAdUnitTypeBanner])
       .andReturn(expectedTokenValue);
   id<CRBannerViewDelegate> mockBannerViewDelegate =
       OCMStrictProtocolMock(@protocol(CRBannerViewDelegate));
@@ -335,45 +252,40 @@
   OCMStub([mockBannerViewDelegate banner:bannerView didFailToReceiveAdWithError:[OCMArg any]]);
   [bannerView loadAdWithBidToken:token];
 
-  CRBannerViewDelegateMock *delegate = [[CRBannerViewDelegateMock alloc] init];
-  delegate.expectedError = [NSError
+  self.delegate.expectedError = [NSError
       cr_errorWithCode:CRErrorCodeInvalidParameter
            description:
                @"Token passed to loadAdWithBidToken doesn't have the same ad unit as the CRBannerView was initialized with"];
-  bannerView.delegate = delegate;
+  bannerView.delegate = self.delegate;
 
   [bannerView loadAdWithBidToken:token];
 
-  [self cr_waitForExpectations:@[ delegate.didFailToReceiveAdWithErrorExpectation ]];
+  [self cr_waitForExpectations:@[ self.delegate.didFailToReceiveAdWithErrorExpectation ]];
 }
 
 - (void)testBannerDidLoadForValidTokenValue {
-  Criteo *mockCriteo = OCMStrictClassMock([Criteo class]);
-  OCMStub(mockCriteo.config).andReturn([[CR_Config alloc] initWithCriteoPublisherId:@"123"]);
   WKWebView *mockWebView = [WKWebView new];
-  CRBannerAdUnit *adUnit1 = [[CRBannerAdUnit alloc] initWithAdUnitId:@"Yo"
-                                                                size:CGSizeMake(200, 200)];
-  CRBannerAdUnit *adUnit2 = [[CRBannerAdUnit alloc] initWithAdUnitId:@"Yo"
-                                                                size:CGSizeMake(200, 200)];
-  CRBannerView *bannerView =
-      [[CRBannerView alloc] initWithFrame:CGRectMake(13.0f, 17.0f, 47.0f, 57.0f)
-                                   criteo:mockCriteo
-                                  webView:mockWebView
-                                   adUnit:adUnit1
-                                urlOpener:self.urlOpener];
+
   CRBidToken *token = [[CRBidToken alloc] initWithUUID:[NSUUID UUID]];
   CR_TokenValue *expectedTokenValue = [CR_TokenValue tokenValueWithDisplayUrl:@"test"
-                                                                       adUnit:adUnit2];
-  ;
-  OCMStub([mockCriteo tokenValueForBidToken:token adUnitType:CRAdUnitTypeBanner])
+                                                                       adUnit:self.adUnit];
+
+  OCMStub([self.criteo tokenValueForBidToken:token adUnitType:CRAdUnitTypeBanner])
       .andReturn(expectedTokenValue);
 
-  CRBannerViewDelegateMock *delegate = [[CRBannerViewDelegateMock alloc] init];
-  bannerView.delegate = delegate;
-
+  CRBannerView *bannerView = [self bannerViewWithWebView:mockWebView];
+  bannerView.delegate = self.delegate;
   [bannerView loadAdWithBidToken:token];
 
-  [self cr_waitForExpectations:@[ delegate.didReceiveAdExpectation ]];
+  [self cr_waitForExpectations:@[ self.delegate.didReceiveAdExpectation ]];
+}
+
+- (CRBannerView *)bannerViewWithWebView:(WKWebView *)webView {
+  return [[CRBannerView alloc] initWithFrame:CGRectMake(13.0f, 17.0f, 47.0f, 57.0f)
+                                      criteo:self.criteo
+                                     webView:webView
+                                      adUnit:self.adUnit
+                                   urlOpener:self.urlOpener];
 }
 
 @end

--- a/CriteoPublisherSdk/Tests/IntegrationTests/CRInterstitialTests.m
+++ b/CriteoPublisherSdk/Tests/IntegrationTests/CRInterstitialTests.m
@@ -39,84 +39,46 @@
 #import "CR_DependencyProvider+Testing.h"
 #import "CR_DisplaySizeInjector.h"
 
-@interface CRInterstitialTests : XCTestCase {
-  CR_CdbBid *_bid;
-  CR_CacheAdUnit *_cacheAdUnit;
-  CRInterstitialAdUnit *_adUnit;
-}
+@interface CRInterstitialTests : XCTestCase
+
+@property(nonatomic, strong) CR_CacheAdUnit *expectedCacheAdUnit;
+@property(nonatomic, strong) CRInterstitialAdUnit *adUnit;
+@property(nonatomic, strong) Criteo *criteo;
+@property(nonatomic, strong) CR_URLOpenerMock *urlOpener;
+@property(nonatomic, strong) CR_DisplaySizeInjector *displaySizeInjector;
+
 @end
 
 @implementation CRInterstitialTests
 
 - (void)setUp {
-  _bid = nil;
-  _cacheAdUnit = nil;
-  _adUnit = nil;
-}
+  self.expectedCacheAdUnit = [[CR_CacheAdUnit alloc] initWithAdUnitId:@"123"
+                                                                 size:CGSizeMake(320.0, 480.0)
+                                                           adUnitType:CRAdUnitTypeInterstitial];
+  self.adUnit = [[CRInterstitialAdUnit alloc] initWithAdUnitId:@"123"];
 
-- (CR_CdbBid *)bidWithDisplayURL:(NSString *)displayURL {
-  if (!_bid) {
-    _bid = [[CR_CdbBid alloc] initWithZoneId:@123
-                                 placementId:@"placementId"
-                                         cpm:@"4.2"
-                                    currency:@"₹😀"
-                                       width:@47.0f
-                                      height:[NSNumber numberWithFloat:57.0f]
-                                         ttl:26
-                                    creative:@"THIS IS USELESS LEGACY"
-                                  displayUrl:displayURL
-                                  insertTime:[NSDate date]
-                                nativeAssets:nil
-                                impressionId:nil];
-  }
-  return _bid;
-}
+  self.urlOpener = CR_URLOpenerMock.new;
 
-- (CR_CacheAdUnit *)expectedCacheAdUnit {
-  if (!_cacheAdUnit) {
-    _cacheAdUnit = [[CR_CacheAdUnit alloc] initWithAdUnitId:@"123"
-                                                       size:CGSizeMake(320.0, 480.0)
-                                                 adUnitType:CRAdUnitTypeInterstitial];
-  }
-  return _cacheAdUnit;
-}
+  CR_DependencyProvider *dependencyProvider = CR_DependencyProvider.testing_dependencyProvider;
 
-- (CRInterstitialAdUnit *)adUnit {
-  if (!_adUnit) {
-    _adUnit = [[CRInterstitialAdUnit alloc] initWithAdUnitId:@"123"];
-  }
-  return _adUnit;
+  self.displaySizeInjector = OCMClassMock([CR_DisplaySizeInjector class]);
+  dependencyProvider.displaySizeInjector = self.displaySizeInjector;
+
+  self.criteo = OCMPartialMock([Criteo.alloc initWithDependencyProvider:dependencyProvider]);
 }
 
 - (void)testInterstitialSuccess {
-  CR_DependencyProvider *dependencyProvider = CR_DependencyProvider.testing_dependencyProvider;
-
-  Criteo *mockCriteo = OCMStrictClassMock([Criteo class]);
-  OCMStub(mockCriteo.config).andReturn([[CR_Config alloc] initWithCriteoPublisherId:@"123"]);
-  OCMStub(mockCriteo.dependencyProvider).andReturn(dependencyProvider);
-
   MockWKWebView *mockWebView = [MockWKWebView new];
-  CR_InterstitialViewController *interstitialVC =
-      [[CR_InterstitialViewController alloc] initWithWebView:mockWebView view:nil interstitial:nil];
-  CRInterstitial *interstitial =
-      [[CRInterstitial alloc] initWithCriteo:mockCriteo
-                              viewController:interstitialVC
-                                  isAdLoaded:NO
-                                      adUnit:self.adUnit
-                                   urlOpener:[[CR_URLOpenerMock alloc] init]];
 
-  id deviceInfoClassMock = OCMClassMock([CR_DeviceInfo class]);
-  OCMStub([deviceInfoClassMock screenSize]).andReturn(CGSizeMake(320, 480));
-  dependencyProvider.deviceInfo = deviceInfoClassMock;
+  [self prepareMockedDeviceInfo];
 
-  CR_DisplaySizeInjector *displaySizeInjector = OCMClassMock([CR_DisplaySizeInjector class]);
-  OCMStub([displaySizeInjector injectSafeScreenSizeInDisplayUrl:@"test"])
+  OCMStub([self.displaySizeInjector injectSafeScreenSizeInDisplayUrl:@"test"])
       .andReturn(@"test?safearea");
-  dependencyProvider.displaySizeInjector = displaySizeInjector;
 
-  OCMExpect([mockCriteo getBid:[self expectedCacheAdUnit]])
+  OCMExpect([self.criteo getBid:[self expectedCacheAdUnit]])
       .andReturn([self bidWithDisplayURL:@"test"]);
 
+  CRInterstitial *interstitial = [self interstitialWithWebView:mockWebView];
   [interstitial loadAd];
 
   XCTAssertTrue(
@@ -125,33 +87,20 @@
 }
 
 - (void)testTemplatingFromConfig {
-  Criteo *mockCriteo = OCMStrictClassMock([Criteo class]);
-
-  CR_DependencyProvider *dependencyProvider = CR_DependencyProvider.testing_dependencyProvider;
-  OCMStub(mockCriteo.dependencyProvider).andReturn(dependencyProvider);
-
   CR_Config *config = [CR_Config new];
   config.adTagUrlMode = @"Good Morning, my width is #WEEDTH# and my URL is ˆURLˆ";
   config.viewportWidthMacro = @"#WEEDTH#";
   config.displayURLMacro = @"ˆURLˆ";
-  OCMExpect(mockCriteo.config).andReturn(config);
+  self.criteo.dependencyProvider.config = config;
 
-  CR_DisplaySizeInjector *displaySizeInjector = OCMClassMock([CR_DisplaySizeInjector class]);
-  OCMStub([displaySizeInjector injectSafeScreenSizeInDisplayUrl:@"whatDoYouMean"])
+  OCMStub([self.displaySizeInjector injectSafeScreenSizeInDisplayUrl:@"whatDoYouMean"])
       .andReturn(@"myUrl");
-  dependencyProvider.displaySizeInjector = displaySizeInjector;
 
   MockWKWebView *mockWebView = [MockWKWebView new];
-  CR_InterstitialViewController *interstitialVC =
-      [[CR_InterstitialViewController alloc] initWithWebView:mockWebView view:nil interstitial:nil];
-  CRInterstitial *interstitial =
-      [[CRInterstitial alloc] initWithCriteo:mockCriteo
-                              viewController:interstitialVC
-                                  isAdLoaded:NO
-                                      adUnit:nil
-                                   urlOpener:[[CR_URLOpenerMock alloc] init]];
-  OCMExpect([mockCriteo getBid:OCMArg.any]).andReturn([self bidWithDisplayURL:@"whatDoYouMean"]);
 
+  OCMExpect([self.criteo getBid:OCMArg.any]).andReturn([self bidWithDisplayURL:@"whatDoYouMean"]);
+
+  CRInterstitial *interstitial = [self interstitialWithWebView:mockWebView];
   [interstitial loadAd];
 
   NSString *expectedHtml =
@@ -162,20 +111,17 @@
 }
 
 - (void)testWebViewAddedToViewHierarchy {
-  Criteo *mockCriteo = OCMStrictClassMock([Criteo class]);
   MockWKWebView *mockWebView = [MockWKWebView new];
+
+  UIViewController *vc = OCMStrictClassMock([UIViewController class]);
+  OCMStub([vc presentViewController:OCMArg.any animated:YES completion:[OCMArg isNotNil]]);
 
   CR_InterstitialViewController *interstitialVC =
       [[CR_InterstitialViewController alloc] initWithWebView:mockWebView view:nil interstitial:nil];
-  CRInterstitial *interstitial =
-      [[CRInterstitial alloc] initWithCriteo:mockCriteo
-                              viewController:interstitialVC
-                                  isAdLoaded:YES
-                                      adUnit:self.adUnit
-                                   urlOpener:[[CR_URLOpenerMock alloc] init]];
-  UIViewController *vc = OCMStrictClassMock([UIViewController class]);
-  OCMStub([vc presentViewController:OCMArg.any animated:YES completion:[OCMArg isNotNil]]);
+  CRInterstitial *interstitial = [self interstitialWithController:interstitialVC];
+  interstitial.isAdLoaded = YES;
   [interstitial presentFromRootViewController:vc];
+
   OCMVerify([vc presentViewController:[OCMArg checkWithBlock:^(id value) {
                   [(UIViewController *)value viewDidAppear:YES];
                   XCTAssertEqual(mockWebView.superview, interstitialVC.view);
@@ -186,27 +132,11 @@
 }
 
 - (void)testWithRendering {
-  CR_DependencyProvider *dependencyProvider = CR_DependencyProvider.testing_dependencyProvider;
-
-  Criteo *mockCriteo = OCMStrictClassMock([Criteo class]);
-  OCMStub(mockCriteo.dependencyProvider).andReturn(dependencyProvider);
-  OCMStub(mockCriteo.config).andReturn([[CR_Config alloc] initWithCriteoPublisherId:@"123"]);
-
   WKWebView *realWebView = [WKWebView new];
-  CR_InterstitialViewController *interstitialVC =
-      [[CR_InterstitialViewController alloc] initWithWebView:realWebView view:nil interstitial:nil];
-  CRInterstitial *interstitial =
-      [[CRInterstitial alloc] initWithCriteo:mockCriteo
-                              viewController:interstitialVC
-                                  isAdLoaded:NO
-                                      adUnit:self.adUnit
-                                   urlOpener:[[CR_URLOpenerMock alloc] init]];
 
   CR_CdbBid *bid = [self bidWithDisplayURL:@"test"];
 
-  id deviceInfoClassMock = OCMClassMock([CR_DeviceInfo class]);
-  OCMStub([deviceInfoClassMock screenSize]).andReturn(CGSizeMake(320, 480));
-  dependencyProvider.deviceInfo = deviceInfoClassMock;
+  [self prepareMockedDeviceInfo];
 
   XCTestExpectation __block *marginExpectation =
       [self expectationWithDescription:@"WebView body has 0px margin"];
@@ -244,38 +174,31 @@
   };
   [CR_Timer scheduledTimerWithTimeInterval:2 repeats:NO block:javascriptChecks];
 
-  OCMStub([mockCriteo getBid:[self expectedCacheAdUnit]]).andReturn(bid);
+  OCMStub([self.criteo getBid:[self expectedCacheAdUnit]]).andReturn(bid);
+
+  CRInterstitial *interstitial = [self interstitialWithWebView:realWebView];
   [interstitial loadAd];
-  OCMVerify([mockCriteo getBid:[self expectedCacheAdUnit]]);
+
+  OCMVerify([self.criteo getBid:[self expectedCacheAdUnit]]);
 
   [self cr_waitForExpectations:@[ marginExpectation, paddingExpectation, viewportExpectation ]];
 }
 
 - (void)testInterstitialFail {
-  CR_DependencyProvider *dependencyProvider = CR_DependencyProvider.testing_dependencyProvider;
-
-  Criteo *mockCriteo = OCMStrictClassMock([Criteo class]);
-  OCMStub(mockCriteo.dependencyProvider).andReturn(dependencyProvider);
-
+  WKWebView *realWebView = [WKWebView new];
   CR_InterstitialViewController *interstitialVC =
       OCMStrictClassMock([CR_InterstitialViewController class]);
-  WKWebView *realWebView = [WKWebView new];
   OCMStub([interstitialVC webView]).andReturn(realWebView);
-  CRInterstitial *interstitial =
-      [[CRInterstitial alloc] initWithCriteo:mockCriteo
-                              viewController:interstitialVC
-                                  isAdLoaded:NO
-                                      adUnit:self.adUnit
-                                   urlOpener:[[CR_URLOpenerMock alloc] init]];
 
-  id deviceInfoClassMock = OCMClassMock([CR_DeviceInfo class]);
-  OCMStub([deviceInfoClassMock screenSize]).andReturn(CGSizeMake(320, 480));
-  dependencyProvider.deviceInfo = deviceInfoClassMock;
+  [self prepareMockedDeviceInfo];
 
-  OCMStub([mockCriteo getBid:[self expectedCacheAdUnit]]).andReturn([CR_CdbBid emptyBid]);
+  OCMStub([self.criteo getBid:[self expectedCacheAdUnit]]).andReturn([CR_CdbBid emptyBid]);
   OCMStub([interstitialVC presentingViewController]).andReturn(nil);
+
+  CRInterstitial *interstitial = [self interstitialWithController:interstitialVC];
   [interstitial loadAd];
-  OCMVerify([mockCriteo getBid:[self expectedCacheAdUnit]]);
+
+  OCMVerify([self.criteo getBid:[self expectedCacheAdUnit]]);
 }
 
 // TODO: UITests for "click" on a "real" webview with a real link
@@ -283,18 +206,12 @@
   /* Allow navigation Types other than Links from Mainframes in WebView.
    eg: Clicking images inside <a> tag generates WKNavigationTypeOther
   */
-  WKWebView *realWebView = [WKWebView new];
-  Criteo *mockCriteo = OCMStrictClassMock([Criteo class]);
-  CR_InterstitialViewController *interstitialVC =
-      [[CR_InterstitialViewController alloc] initWithWebView:realWebView view:nil interstitial:nil];
-  CRInterstitial *interstitial =
-      [[CRInterstitial alloc] initWithCriteo:mockCriteo
-                              viewController:interstitialVC
-                                  isAdLoaded:NO
-                                      adUnit:self.adUnit
-                                   urlOpener:[[CR_URLOpenerMock alloc] init]];
   WKNavigationAction *mockNavigationAction = OCMStrictClassMock([WKNavigationAction class]);
   OCMStub(mockNavigationAction.navigationType).andReturn(WKNavigationTypeOther);
+
+  WKWebView *realWebView = [WKWebView new];
+  CRInterstitial *interstitial = [self interstitialWithWebView:realWebView];
+
   [interstitial webView:realWebView
       decidePolicyForNavigationAction:mockNavigationAction
                       decisionHandler:^(WKNavigationActionPolicy actionPolicy) {
@@ -316,17 +233,8 @@
 }
 
 - (void)testCancelNavigationActionPolicyForWebView {
-  CR_URLOpenerMock *opener = [[CR_URLOpenerMock alloc] init];
   // cancel webView navigation for clicks on Links from mainFrame and open in browser
   WKWebView *realWebView = [WKWebView new];
-  Criteo *mockCriteo = OCMStrictClassMock([Criteo class]);
-  CR_InterstitialViewController *interstitialVC =
-      [[CR_InterstitialViewController alloc] initWithWebView:realWebView view:nil interstitial:nil];
-  CRInterstitial *interstitial = [[CRInterstitial alloc] initWithCriteo:mockCriteo
-                                                         viewController:interstitialVC
-                                                             isAdLoaded:NO
-                                                                 adUnit:self.adUnit
-                                                              urlOpener:opener];
 
   WKNavigationAction *mockNavigationAction = OCMStrictClassMock([WKNavigationAction class]);
   OCMStub(mockNavigationAction.navigationType).andReturn(WKNavigationTypeLinkActivated);
@@ -339,6 +247,8 @@
 
   XCTestExpectation *openInBrowserExpectation =
       [self expectationWithDescription:@"URL opened in browser expectation"];
+
+  CRInterstitial *interstitial = [self interstitialWithWebView:realWebView];
   [interstitial webView:realWebView
       decidePolicyForNavigationAction:mockNavigationAction
                       decisionHandler:^(WKNavigationActionPolicy actionPolicy) {
@@ -346,7 +256,7 @@
                       }];
 
   dispatch_async(dispatch_get_main_queue(), ^{
-    XCTAssertEqual(opener.openExternalURLCount, 1);
+    XCTAssertEqual(self.urlOpener.openExternalURLCount, 1);
     [openInBrowserExpectation fulfill];
   });
 
@@ -356,16 +266,7 @@
 // Test window.open navigation delegate
 // TODO: UITests for "window.open" in a "real" webview
 - (void)testCreateWebViewWithConfiguration {
-  CR_URLOpenerMock *opener = [[CR_URLOpenerMock alloc] init];
   WKWebView *realWebView = [WKWebView new];
-  Criteo *mockCriteo = OCMStrictClassMock([Criteo class]);
-  CR_InterstitialViewController *interstitialVC =
-      [[CR_InterstitialViewController alloc] initWithWebView:realWebView view:nil interstitial:nil];
-  CRInterstitial *interstitial = [[CRInterstitial alloc] initWithCriteo:mockCriteo
-                                                         viewController:interstitialVC
-                                                             isAdLoaded:NO
-                                                                 adUnit:nil
-                                                              urlOpener:opener];
 
   WKNavigationAction *mockNavigationAction = OCMStrictClassMock([WKNavigationAction class]);
   OCMStub(mockNavigationAction.navigationType).andReturn(WKNavigationTypeOther);
@@ -378,13 +279,15 @@
 
   XCTestExpectation *openInBrowserExpectation =
       [self expectationWithDescription:@"URL opened in browser expectation"];
+
+  CRInterstitial *interstitial = [self interstitialWithWebView:realWebView];
   [interstitial webView:realWebView
       createWebViewWithConfiguration:nil
                  forNavigationAction:mockNavigationAction
                       windowFeatures:nil];
 
   dispatch_async(dispatch_get_main_queue(), ^{
-    XCTAssertEqual(opener.openExternalURLCount, 1);
+    XCTAssertEqual(self.urlOpener.openExternalURLCount, 1);
     [openInBrowserExpectation fulfill];
   });
 
@@ -393,45 +296,59 @@
 
 // Android:  whenLoadingAnInterstitial_GivenInitializedSdk_ShouldSetInterstitialFlagInTheRequest
 - (void)testLoadingInterstitialShouldSetInterstitialFlagInTheRequest {
-  Criteo *criteo = [Criteo testing_criteoWithNetworkCaptor];
-  [criteo testing_registerInterstitialAndWaitForHTTPResponses];
+  [self.criteo testing_registerInterstitialAndWaitForHTTPResponses];
   XCTestExpectation *interstitialHttpCallExpectation =
       [self expectationWithDescription:@"configApiCallExpectation"];
-  criteo.testing_networkCaptor.requestListener =
+  self.criteo.testing_networkCaptor.requestListener =
       ^(NSURL *_Nonnull url, CR_HTTPVerb verb, NSDictionary *body) {
-        const BOOL isBidURL = [url.absoluteString containsString:criteo.config.cdbUrl];
+        const BOOL isBidURL = [url.absoluteString containsString:self.criteo.config.cdbUrl];
         const BOOL isInterstitialPresent = [body[@"slots"][0][@"interstitial"] boolValue];
         if (isBidURL && isInterstitialPresent) {
           [interstitialHttpCallExpectation fulfill];
         }
       };
 
-  [self _loadInterstitialAdWithCriteo:criteo];
+  MockWKWebView *mockWebView = [[MockWKWebView alloc] init];
+
+  CRInterstitial *interstitial = [self interstitialWithWebView:mockWebView];
+  [interstitial loadAd];
 
   [self cr_waitForExpectations:@[ interstitialHttpCallExpectation ]];
 }
 
-- (void)_loadInterstitialAdWithCriteo:(Criteo *)criteo {
-  MockWKWebView *mockWebView = [[MockWKWebView alloc] init];
+- (void)prepareMockedDeviceInfo {
+  id deviceInfoClassMock = OCMClassMock([CR_DeviceInfo class]);
+  OCMStub([deviceInfoClassMock screenSize]).andReturn(CGSizeMake(320, 480));
+  self.criteo.dependencyProvider.deviceInfo = deviceInfoClassMock;
+}
+
+- (CR_CdbBid *)bidWithDisplayURL:(NSString *)displayURL {
+  return [[CR_CdbBid alloc] initWithZoneId:@123
+                               placementId:@"placementId"
+                                       cpm:@"4.2"
+                                  currency:@"₹😀"
+                                     width:@47.0f
+                                    height:@57.0f
+                                       ttl:26
+                                  creative:@"THIS IS USELESS LEGACY"
+                                displayUrl:displayURL
+                                insertTime:[NSDate date]
+                              nativeAssets:nil
+                              impressionId:nil];
+}
+
+- (CRInterstitial *)interstitialWithController:(CR_InterstitialViewController *)controller {
+  return [[CRInterstitial alloc] initWithCriteo:self.criteo
+                                 viewController:controller
+                                     isAdLoaded:NO
+                                         adUnit:self.adUnit
+                                      urlOpener:self.urlOpener];
+}
+
+- (CRInterstitial *)interstitialWithWebView:(WKWebView *)webView {
   CR_InterstitialViewController *interstitialVC =
-      [[CR_InterstitialViewController alloc] initWithWebView:mockWebView view:nil interstitial:nil];
-  CRInterstitial *interstitial =
-      [[CRInterstitial alloc] initWithCriteo:criteo
-                              viewController:interstitialVC
-                                  isAdLoaded:NO
-                                      adUnit:self.adUnit
-                                   urlOpener:[[CR_URLOpenerMock alloc] init]];
-  [interstitial loadAd];
+      [[CR_InterstitialViewController alloc] initWithWebView:webView view:nil interstitial:nil];
+  return [self interstitialWithController:interstitialVC];
 }
-
-/*
-- (CR_InterstitialViewController *)_interstitialViewController
-{
-    MockWKWebView *mockWebView = [[MockWKWebView alloc] init];
-    CR_InterstitialViewController *interstitialVC = [[CR_InterstitialViewController alloc]
-initWithWebView:mockWebView view:nil interstitial:nil];
-
-}
- */
 
 @end

--- a/CriteoPublisherSdk/Tests/IntegrationTests/CRInterstitialTests.m
+++ b/CriteoPublisherSdk/Tests/IntegrationTests/CRInterstitialTests.m
@@ -38,6 +38,7 @@
 #import "NSURL+Criteo.h"
 #import "CR_DependencyProvider+Testing.h"
 #import "CR_DisplaySizeInjector.h"
+#import "CR_IntegrationRegistry.h"
 
 @interface CRInterstitialTests : XCTestCase
 
@@ -46,6 +47,7 @@
 @property(nonatomic, strong) Criteo *criteo;
 @property(nonatomic, strong) CR_URLOpenerMock *urlOpener;
 @property(nonatomic, strong) CR_DisplaySizeInjector *displaySizeInjector;
+@property(nonatomic, strong) CR_IntegrationRegistry *integrationRegistry;
 
 @end
 
@@ -59,10 +61,12 @@
 
   self.urlOpener = CR_URLOpenerMock.new;
 
-  CR_DependencyProvider *dependencyProvider = CR_DependencyProvider.testing_dependencyProvider;
-
   self.displaySizeInjector = OCMClassMock([CR_DisplaySizeInjector class]);
+  self.integrationRegistry = OCMClassMock([CR_IntegrationRegistry class]);
+
+  CR_DependencyProvider *dependencyProvider = CR_DependencyProvider.testing_dependencyProvider;
   dependencyProvider.displaySizeInjector = self.displaySizeInjector;
+  dependencyProvider.integrationRegistry = self.integrationRegistry;
 
   self.criteo = OCMPartialMock([Criteo.alloc initWithDependencyProvider:dependencyProvider]);
 }
@@ -84,6 +88,7 @@
   XCTAssertTrue(
       [mockWebView.loadedHTMLString containsString:@"<script src=\"test?safearea\"></script>"]);
   XCTAssertEqualObjects([NSURL URLWithString:@"https://criteo.com"], mockWebView.loadedBaseURL);
+  OCMVerify([self.integrationRegistry declare:CR_IntegrationStandalone]);
 }
 
 - (void)testTemplatingFromConfig {
@@ -199,6 +204,7 @@
   [interstitial loadAd];
 
   OCMVerify([self.criteo getBid:[self expectedCacheAdUnit]]);
+  OCMVerify([self.integrationRegistry declare:CR_IntegrationStandalone]);
 }
 
 // TODO: UITests for "click" on a "real" webview with a real link

--- a/CriteoPublisherSdk/Tests/UnitTests/CR_BidManagerHelperTests.m
+++ b/CriteoPublisherSdk/Tests/UnitTests/CR_BidManagerHelperTests.m
@@ -26,6 +26,7 @@
 #import "CR_HeaderBidding.h"
 #import "CR_DeviceInfoMock.h"
 #import "CR_DisplaySizeInjector.h"
+#import "CR_DependencyProvider.h"
 
 @interface CR_BidManagerHelperTests : XCTestCase
 
@@ -34,10 +35,10 @@
 @implementation CR_BidManagerHelperTests
 
 - (void)testRemoveCriteoBidFromMopubAdRequest {
-  CR_DisplaySizeInjector *displaySizeInjector = OCMClassMock([CR_DisplaySizeInjector class]);
-  CR_DeviceInfoMock *device = [[CR_DeviceInfoMock alloc] init];
-  CR_HeaderBidding *headerBidding = [[CR_HeaderBidding alloc] initWithDevice:device
-                                                         displaySizeInjector:displaySizeInjector];
+  CR_DependencyProvider *dependencyProvider = CR_DependencyProvider.new;
+  dependencyProvider.displaySizeInjector = OCMClassMock([CR_DisplaySizeInjector class]);
+  dependencyProvider.deviceInfo = [[CR_DeviceInfoMock alloc] init];
+  CR_HeaderBidding *headerBidding = dependencyProvider.headerBidding;
   CR_CacheAdUnit *slot_1 = [[CR_CacheAdUnit alloc] initWithAdUnitId:@"adunitid"
                                                               width:300
                                                              height:250];
@@ -55,7 +56,8 @@
         nativeAssets:nil
         impressionId:nil];
 
-  OCMStub([displaySizeInjector injectSafeScreenSizeInDisplayUrl:testBid_1.displayUrl])
+  OCMStub([dependencyProvider.displaySizeInjector
+              injectSafeScreenSizeInDisplayUrl:testBid_1.displayUrl])
       .andReturn(testBid_1.displayUrl);
 
   MPInterstitialAdController *mopubBidRequest = [[MPInterstitialAdController alloc] init];

--- a/CriteoPublisherSdk/Tests/UnitTests/CriteoTests.m
+++ b/CriteoPublisherSdk/Tests/UnitTests/CriteoTests.m
@@ -1,0 +1,55 @@
+//
+//  CriteoTests.m
+//  CriteoPublisherSdk
+//
+//  Copyright © 2018-2020 Criteo. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import <XCTest/XCTest.h>
+#import <OCMock.h>
+#import "Criteo.h"
+#import "Criteo+Internal.h"
+#import "CRInterstitialAdUnit.h"
+#import "CR_IntegrationRegistry.h"
+#import "CR_DependencyProvider.h"
+#import "CR_DependencyProvider+Testing.h"
+
+@interface CriteoTests : XCTestCase
+
+@property(strong, nonatomic) Criteo *criteo;
+@property(strong, nonatomic) CR_IntegrationRegistry *integrationRegistry;
+
+@end
+
+@implementation CriteoTests
+
+- (void)setUp {
+  self.integrationRegistry = OCMClassMock([CR_IntegrationRegistry class]);
+
+  CR_DependencyProvider *dependencyProvider = CR_DependencyProvider.testing_dependencyProvider;
+  dependencyProvider.integrationRegistry = self.integrationRegistry;
+
+  self.criteo = [[Criteo alloc] initWithDependencyProvider:dependencyProvider];
+}
+
+- (void)testGetBidResponseForAdUnit_GivenAnyState_DeclareInHouseIntegration {
+  CRAdUnit *adUnit = [[CRInterstitialAdUnit alloc] initWithAdUnitId:@"adUnit"];
+
+  [self.criteo getBidResponseForAdUnit:adUnit];
+
+  OCMVerify([self.integrationRegistry declare:CR_IntegrationInHouse]);
+}
+
+@end

--- a/CriteoPublisherSdk/Tests/UnitTests/Standalone/CRBannerViewTests.m
+++ b/CriteoPublisherSdk/Tests/UnitTests/Standalone/CRBannerViewTests.m
@@ -32,74 +32,51 @@
 #import "NSURL+Criteo.h"
 #import "CR_TokenValue+Testing.h"
 #import "XCTestCase+Criteo.h"
+#import "CR_DependencyProvider+Testing.h"
 
 @import WebKit;
 
 @interface CRBannerViewTests : XCTestCase <WKNavigationDelegate>
 
 @property(nonatomic, copy) void (^webViewDidLoadBlock)(void);
-@property(nonatomic, strong) CR_CacheAdUnit *cacheAdUnit;
+@property(nonatomic, strong) CR_CacheAdUnit *expectedCacheAdUnit;
 @property(nonatomic, strong) CRBannerAdUnit *adUnit;
 @property(strong, nonatomic) CR_URLOpenerMock *urlOpener;
+@property(strong, nonatomic) Criteo *criteo;
 
 @end
 
 @implementation CRBannerViewTests
 
 - (void)setUp {
-  _cacheAdUnit = nil;
-  _adUnit = nil;
+  self.expectedCacheAdUnit = [[CR_CacheAdUnit alloc] initWithAdUnitId:@"123"
+                                                                 size:CGSizeMake(47.0, 57.0)
+                                                           adUnitType:CRAdUnitTypeBanner];
+  self.adUnit = [[CRBannerAdUnit alloc] initWithAdUnitId:@"123" size:CGSizeMake(47.0, 57.0)];
   self.urlOpener = [[CR_URLOpenerMock alloc] init];
+
+  CR_DependencyProvider *dependencyProvider = CR_DependencyProvider.testing_dependencyProvider;
+  self.criteo = OCMPartialMock([Criteo.alloc initWithDependencyProvider:dependencyProvider]);
 }
 
-- (CR_CacheAdUnit *)expectedCacheAdUnit {
-  if (!_cacheAdUnit) {
-    _cacheAdUnit = [[CR_CacheAdUnit alloc] initWithAdUnitId:@"123"
-                                                       size:CGSizeMake(47.0, 57.0)
-                                                 adUnitType:CRAdUnitTypeBanner];
-  }
-  return _cacheAdUnit;
-}
-
-- (CRBannerAdUnit *)adUnit {
-  if (!_adUnit) {
-    _adUnit = [[CRBannerAdUnit alloc] initWithAdUnitId:@"123" size:CGSizeMake(47.0, 57.0)];
-  }
-  return _adUnit;
+- (void)tearDown {
+  // Not sure why this is needed but without this testWithRendering is failing.
+  // Maybe this come from OCMock not handling properly partial mock ???
+  self.criteo = nil;
 }
 
 - (void)testBannerSuccess {
-  Criteo *mockCriteo = OCMStrictClassMock([Criteo class]);
-  OCMStub(mockCriteo.config).andReturn([[CR_Config alloc] initWithCriteoPublisherId:@"123"]);
   MockWKWebView *mockWebView = [MockWKWebView new];
-
-  CRBannerView *bannerView =
-      [[CRBannerView alloc] initWithFrame:CGRectMake(13.0f, 17.0f, 47.0f, 57.0f)
-                                   criteo:mockCriteo
-                                  webView:mockWebView
-                                   adUnit:self.adUnit
-                                urlOpener:self.urlOpener];
 
   NSString *displayURL =
       @"https://rdi.eu.criteo.com/delivery/r/ajs.php?did=5c98e9d9c574a3589f8e9465fce67b00&u=%7Cx8O2jgV2RMISbZvm2b09FrpmynuoN27jeqtp1aMfZdU%3D%7C&c1=oP5_e7JVVt0EkjVehxP6aIOIWS-fm2fzhyMXUboeuR1zkGydE3HlloxT1QAbHNNgeH7t9e1IR6mv0biMxm46ZSFdAXZXreJVeP6QwU8IPLUsA32HNafhqgpnKTwmx9RrrJm4CS5Wqj07vNY7UTgDei8AWqc5CGPT2wm7W02JRvgN2kA-oWbWifmmm6EPpqVZijDHDzXwaNgzrfsaEodEmYAjFepGF0mdElHoFUCPKuOtc7mUQijLG0BSS9RhwrCTcAv42KkEQ359Et_eDnQcSt9OAF3bL64QIvLQxt2ekYFNuv3zng03qL0DIHS2bDJwRb3ieUlvZCWHI49OqM5PqoGDpSzdhdwfTE18L6cOOVKqPQ0dPofN4dkSs9IbVGiYlPnjfibL88PwTspYvki2svidSDIa2agQMHVgEof8YY4x4VgPjA8XY-s93ttw_i-RN3lcQn2mGEp6FYmRsyjFEDxHgGfJ0j6U";
+  CR_CdbBid *bid = [self cdbBidWithDisplayUrl:displayURL];
+  OCMStub([self.criteo getBid:[self expectedCacheAdUnit]]).andReturn(bid);
 
-  CR_CdbBid *bid = [[CR_CdbBid alloc] initWithZoneId:@123
-                                         placementId:@"placementId"
-                                                 cpm:@"4.2"
-                                            currency:@"₹😀"
-                                               width:@47.0f
-                                              height:[NSNumber numberWithFloat:57.0f]
-                                                 ttl:26
-                                            creative:@"THIS IS USELESS LEGACY"
-                                          displayUrl:displayURL
-                                          insertTime:[NSDate date]
-                                        nativeAssets:nil
-                                        impressionId:nil];
-
-  OCMStub([mockCriteo getBid:[self expectedCacheAdUnit]]).andReturn(bid);
-
+  CRBannerView *bannerView = [self bannerViewWithWebView:mockWebView];
   [bannerView loadAd];
-  OCMVerify([mockCriteo getBid:[self expectedCacheAdUnit]]);
+
+  OCMVerify([self.criteo getBid:[self expectedCacheAdUnit]]);
 
   XCTAssertTrue([mockWebView.loadedHTMLString
       containsString:
@@ -108,47 +85,23 @@
 }
 
 - (void)testWebViewAddedToViewHierarchy {
-  Criteo *mockCriteo = OCMStrictClassMock([Criteo class]);
   MockWKWebView *mockWebView = [MockWKWebView new];
-  CRBannerView *bannerView =
-      [[CRBannerView alloc] initWithFrame:CGRectMake(13.0f, 17.0f, 47.0f, 57.0f)
-                                   criteo:mockCriteo
-                                  webView:mockWebView
-                                   adUnit:self.adUnit
-                                urlOpener:self.urlOpener];
-  XCTAssertEqual(mockWebView, [bannerView.subviews objectAtIndex:0]);
+
+  CRBannerView *bannerView = [self bannerViewWithWebView:mockWebView];
+
+  XCTAssertEqual(mockWebView, bannerView.subviews[0]);
 }
 
 - (void)testWithRendering {
-  Criteo *mockCriteo = OCMStrictClassMock([Criteo class]);
-  OCMStub(mockCriteo.config).andReturn([[CR_Config alloc] initWithCriteoPublisherId:@"123"]);
   WKWebView *realWebView = [WKWebView new];
-  CRBannerView *bannerView =
-      [[CRBannerView alloc] initWithFrame:CGRectMake(13.0f, 17.0f, 47.0f, 57.0f)
-                                   criteo:mockCriteo
-                                  webView:realWebView
-                                   adUnit:self.adUnit
-                                urlOpener:self.urlOpener];
+
+  CR_CdbBid *bid = [self cdbBidWithDisplayUrl:@""];
+  OCMStub([self.criteo getBid:[self expectedCacheAdUnit]]).andReturn(bid);
+
+  CRBannerView *bannerView = [self bannerViewWithWebView:realWebView];
   realWebView.navigationDelegate = self;
-
-  NSString *displayURL = @"";
-
-  CR_CdbBid *bid = [[CR_CdbBid alloc] initWithZoneId:@123
-                                         placementId:@"placementId"
-                                                 cpm:@"4.2"
-                                            currency:@"₹😀"
-                                               width:@47.0f
-                                              height:[NSNumber numberWithFloat:57.0f]
-                                                 ttl:26
-                                            creative:@"THIS IS USELESS LEGACY"
-                                          displayUrl:displayURL
-                                          insertTime:[NSDate date]
-                                        nativeAssets:nil
-                                        impressionId:nil];
-
-  OCMStub([mockCriteo getBid:[self expectedCacheAdUnit]]).andReturn(bid);
-
   [bannerView loadAd];
+
   XCTestExpectation __block *marginExpectation =
       [self expectationWithDescription:@"WebView body has 0px margin"];
   XCTestExpectation __block *paddingExpectation =
@@ -188,18 +141,13 @@
 }
 
 - (void)testBannerFail {
-  Criteo *mockCriteo = OCMStrictClassMock([Criteo class]);
-  OCMStub(mockCriteo.config).andReturn([[CR_Config alloc] initWithCriteoPublisherId:@"123"]);
   WKWebView *realWebView = [WKWebView new];
-  CRBannerView *bannerView =
-      [[CRBannerView alloc] initWithFrame:CGRectMake(13.0f, 17.0f, 47.0f, 57.0f)
-                                   criteo:mockCriteo
-                                  webView:realWebView
-                                   adUnit:self.adUnit
-                                urlOpener:self.urlOpener];
-  OCMStub([mockCriteo getBid:[self expectedCacheAdUnit]]).andReturn(nil);
+  OCMStub([self.criteo getBid:[self expectedCacheAdUnit]]).andReturn(nil);
+
+  CRBannerView *bannerView = [self bannerViewWithWebView:realWebView];
   [bannerView loadAd];
-  OCMVerify([mockCriteo getBid:[self expectedCacheAdUnit]]);
+
+  OCMVerify([self.criteo getBid:[self expectedCacheAdUnit]]);
 }
 
 // TODO: UITests for "click" on a "real" webview with a real link
@@ -207,12 +155,8 @@
   /* Allow navigation Types other than Links from Mainframes in WebView.
    eg: Clicking images inside <a> tag generates WKNavigationTypeOther
    */
-  CRBannerView *bannerView =
-      [[CRBannerView alloc] initWithFrame:CGRectMake(13.0f, 17.0f, 47.0f, 57.0f)
-                                   criteo:nil
-                                  webView:nil
-                                   adUnit:self.adUnit
-                                urlOpener:self.urlOpener];
+  CRBannerView *bannerView = [self bannerViewWithWebView:nil];
+
   WKNavigationAction *mockNavigationAction = OCMStrictClassMock([WKNavigationAction class]);
   OCMStub(mockNavigationAction.navigationType).andReturn(WKNavigationTypeOther);
   [bannerView webView:nil
@@ -237,13 +181,6 @@
 
 - (void)testCancelNavigationActionPolicyForWebView {
   // cancel webView navigation for clicks on Links from mainFrame and open in browser
-  CRBannerView *bannerView =
-      [[CRBannerView alloc] initWithFrame:CGRectMake(13.0f, 17.0f, 47.0f, 57.0f)
-                                   criteo:nil
-                                  webView:nil
-                                   adUnit:self.adUnit
-                                urlOpener:self.urlOpener];
-
   WKNavigationAction *mockNavigationAction = OCMStrictClassMock([WKNavigationAction class]);
   OCMStub(mockNavigationAction.navigationType).andReturn(WKNavigationTypeLinkActivated);
   WKFrameInfo *mockFrame = OCMStrictClassMock([WKFrameInfo class]);
@@ -255,6 +192,8 @@
 
   XCTestExpectation *openInBrowserExpectation =
       [self expectationWithDescription:@"URL opened in browser expectation"];
+
+  CRBannerView *bannerView = [self bannerViewWithWebView:nil];
   [bannerView webView:nil
       decidePolicyForNavigationAction:mockNavigationAction
                       decisionHandler:^(WKNavigationActionPolicy actionPolicy) {
@@ -273,13 +212,6 @@
 // TODO: (U)ITests for "window.open" in a "real" webview
 - (void)testCreateWebViewWithConfiguration {
   WKWebView *realWebView = [WKWebView new];
-  Criteo *mockCriteo = OCMStrictClassMock([Criteo class]);
-  CRBannerView *bannerView =
-      [[CRBannerView alloc] initWithFrame:CGRectMake(13.0f, 17.0f, 47.0f, 57.0f)
-                                   criteo:mockCriteo
-                                  webView:realWebView
-                                   adUnit:nil
-                                urlOpener:self.urlOpener];
 
   WKNavigationAction *mockNavigationAction = OCMStrictClassMock([WKNavigationAction class]);
 
@@ -293,6 +225,8 @@
 
   XCTestExpectation *openInBrowserExpectation =
       [self expectationWithDescription:@"URL opened in browser expectation"];
+
+  CRBannerView *bannerView = [self bannerViewWithWebView:realWebView];
   [bannerView webView:realWebView
       createWebViewWithConfiguration:nil
                  forNavigationAction:mockNavigationAction
@@ -309,25 +243,18 @@
 #pragma inhouseSpecificTests
 
 - (void)testLoadingSuccess {
-  Criteo *mockCriteo = OCMStrictClassMock([Criteo class]);
-  OCMStub(mockCriteo.config).andReturn([[CR_Config alloc] initWithCriteoPublisherId:@"123"]);
   MockWKWebView *mockWebView = [MockWKWebView new];
-  CRBannerView *bannerView =
-      [[CRBannerView alloc] initWithFrame:CGRectMake(13.0f, 17.0f, 47.0f, 57.0f)
-                                   criteo:mockCriteo
-                                  webView:mockWebView
-                                   adUnit:self.adUnit
-                                urlOpener:self.urlOpener];
   CRBidToken *token = [[CRBidToken alloc] initWithUUID:[NSUUID UUID]];
   NSString *displayURL =
       @"https://rdi.eu.criteo.com/delivery/r/ajs.php?did=5c98e9d9c574a3589f8e9465fce67b00&u=%7Cx8O2jgV2RMISbZvm2b09FrpmynuoN27jeqtp1aMfZdU%3D%7C&c1=oP5_e7JVVt0EkjVehxP6aIOIWS-fm2fzhyMXUboeuR1zkGydE3HlloxT1QAbHNNgeH7t9e1IR6mv0biMxm46ZSFdAXZXreJVeP6QwU8IPLUsA32HNafhqgpnKTwmx9RrrJm4CS5Wqj07vNY7UTgDei8AWqc5CGPT2wm7W02JRvgN2kA-oWbWifmmm6EPpqVZijDHDzXwaNgzrfsaEodEmYAjFepGF0mdElHoFUCPKuOtc7mUQijLG0BSS9RhwrCTcAv42KkEQ359Et_eDnQcSt9OAF3bL64QIvLQxt2ekYFNuv3zng03qL0DIHS2bDJwRb3ieUlvZCWHI49OqM5PqoGDpSzdhdwfTE18L6cOOVKqPQ0dPofN4dkSs9IbVGiYlPnjfibL88PwTspYvki2svidSDIa2agQMHVgEof8YY4x4VgPjA8XY-s93ttw_i-RN3lcQn2mGEp6FYmRsyjFEDxHgGfJ0j6U";
-  CRAdUnit *adUnit = [[CRAdUnit alloc] initWithAdUnitId:@"123" adUnitType:CRAdUnitTypeBanner];
   CR_TokenValue *expectedTokenValue = [CR_TokenValue tokenValueWithDisplayUrl:displayURL
-                                                                       adUnit:adUnit];
-  OCMStub([mockCriteo tokenValueForBidToken:token adUnitType:CRAdUnitTypeBanner])
+                                                                       adUnit:self.adUnit];
+  OCMStub([self.criteo tokenValueForBidToken:token adUnitType:CRAdUnitTypeBanner])
       .andReturn(expectedTokenValue);
 
+  CRBannerView *bannerView = [self bannerViewWithWebView:mockWebView];
   [bannerView loadAdWithBidToken:token];
+
   XCTAssertTrue([mockWebView.loadedHTMLString
       containsString:
           @"<script src=\"https://rdi.eu.criteo.com/delivery/r/ajs.php?did=5c98e9d9c574a3589f8e9465fce67b00&u=%7Cx8O2jgV2RMISbZvm2b09FrpmynuoN27jeqtp1aMfZdU%3D%7C&c1=oP5_e7JVVt0EkjVehxP6aIOIWS-fm2fzhyMXUboeuR1zkGydE3HlloxT1QAbHNNgeH7t9e1IR6mv0biMxm46ZSFdAXZXreJVeP6QwU8IPLUsA32HNafhqgpnKTwmx9RrrJm4CS5Wqj07vNY7UTgDei8AWqc5CGPT2wm7W02JRvgN2kA-oWbWifmmm6EPpqVZijDHDzXwaNgzrfsaEodEmYAjFepGF0mdElHoFUCPKuOtc7mUQijLG0BSS9RhwrCTcAv42KkEQ359Et_eDnQcSt9OAF3bL64QIvLQxt2ekYFNuv3zng03qL0DIHS2bDJwRb3ieUlvZCWHI49OqM5PqoGDpSzdhdwfTE18L6cOOVKqPQ0dPofN4dkSs9IbVGiYlPnjfibL88PwTspYvki2svidSDIa2agQMHVgEof8YY4x4VgPjA8XY-s93ttw_i-RN3lcQn2mGEp6FYmRsyjFEDxHgGfJ0j6U\"></script>"]);
@@ -335,34 +262,24 @@
 }
 
 - (void)testTemplatingFromConfig {
-  Criteo *mockCriteo = OCMStrictClassMock([Criteo class]);
   CR_Config *config = [CR_Config new];
   config.adTagUrlMode = @"Good Morning, my width is #WEEDTH# and my URL is ˆURLˆ";
   config.viewportWidthMacro = @"#WEEDTH#";
   config.displayURLMacro = @"ˆURLˆ";
-  OCMExpect(mockCriteo.config).andReturn(config);
-
-  CRBannerAdUnit *adUnit1 = [[CRBannerAdUnit alloc] initWithAdUnitId:@"Adrian"
-                                                                size:CGSizeMake(300, 300)];
-  CRBannerAdUnit *adUnit2 = [[CRBannerAdUnit alloc] initWithAdUnitId:@"Adrian"
-                                                                size:CGSizeMake(300, 300)];
+  self.criteo.dependencyProvider.config = config;
 
   MockWKWebView *mockWebView = [MockWKWebView new];
-  CRBannerView *bannerView =
-      [[CRBannerView alloc] initWithFrame:CGRectMake(13.0f, 17.0f, 47.0f, 57.0f)
-                                   criteo:mockCriteo
-                                  webView:mockWebView
-                                   adUnit:adUnit1
-                                urlOpener:self.urlOpener];
 
   CRBidToken *token = [[CRBidToken alloc] initWithUUID:[NSUUID UUID]];
   NSString *displayURL = @"whatDoYouMean";
   CR_TokenValue *expectedTokenValue = [CR_TokenValue tokenValueWithDisplayUrl:displayURL
-                                                                       adUnit:adUnit2];
-  OCMStub([mockCriteo tokenValueForBidToken:token adUnitType:CRAdUnitTypeBanner])
+                                                                       adUnit:self.adUnit];
+  OCMStub([self.criteo tokenValueForBidToken:token adUnitType:CRAdUnitTypeBanner])
       .andReturn(expectedTokenValue);
 
+  CRBannerView *bannerView = [self bannerViewWithWebView:mockWebView];
   [bannerView loadAdWithBidToken:token];
+
   XCTAssertEqualObjects(mockWebView.loadedHTMLString,
                         @"Good Morning, my width is 47 and my URL is whatDoYouMean");
 }
@@ -385,6 +302,29 @@
   XCTAssertNil(error);
   XCTAssertTrue([(NSString *)result containsString:@"width=47"]);
   [expectation fulfill];
+}
+
+- (CRBannerView *)bannerViewWithWebView:(WKWebView *)webView {
+  return [[CRBannerView alloc] initWithFrame:CGRectMake(13.0f, 17.0f, 47.0f, 57.0f)
+                                      criteo:self.criteo
+                                     webView:webView
+                                      adUnit:self.adUnit
+                                   urlOpener:self.urlOpener];
+}
+
+- (CR_CdbBid *)cdbBidWithDisplayUrl:(NSString *)displayURL {
+  return [[CR_CdbBid alloc] initWithZoneId:@123
+                               placementId:@"placementId"
+                                       cpm:@"4.2"
+                                  currency:@"₹😀"
+                                     width:@47.0f
+                                    height:@57.0f
+                                       ttl:26
+                                  creative:@"THIS IS USELESS LEGACY"
+                                displayUrl:displayURL
+                                insertTime:[NSDate date]
+                              nativeAssets:nil
+                              impressionId:nil];
 }
 
 @end

--- a/CriteoPublisherSdk/Tests/UnitTests/Standalone/CRBannerViewTests.m
+++ b/CriteoPublisherSdk/Tests/UnitTests/Standalone/CRBannerViewTests.m
@@ -33,6 +33,7 @@
 #import "CR_TokenValue+Testing.h"
 #import "XCTestCase+Criteo.h"
 #import "CR_DependencyProvider+Testing.h"
+#import "CR_IntegrationRegistry.h"
 
 @import WebKit;
 
@@ -43,6 +44,7 @@
 @property(nonatomic, strong) CRBannerAdUnit *adUnit;
 @property(strong, nonatomic) CR_URLOpenerMock *urlOpener;
 @property(strong, nonatomic) Criteo *criteo;
+@property(strong, nonatomic) CR_IntegrationRegistry *integrationRegistry;
 
 @end
 
@@ -55,7 +57,11 @@
   self.adUnit = [[CRBannerAdUnit alloc] initWithAdUnitId:@"123" size:CGSizeMake(47.0, 57.0)];
   self.urlOpener = [[CR_URLOpenerMock alloc] init];
 
+  self.integrationRegistry = OCMClassMock([CR_IntegrationRegistry class]);
+
   CR_DependencyProvider *dependencyProvider = CR_DependencyProvider.testing_dependencyProvider;
+  dependencyProvider.integrationRegistry = self.integrationRegistry;
+
   self.criteo = OCMPartialMock([Criteo.alloc initWithDependencyProvider:dependencyProvider]);
 }
 
@@ -82,6 +88,7 @@
       containsString:
           @"<script src=\"https://rdi.eu.criteo.com/delivery/r/ajs.php?did=5c98e9d9c574a3589f8e9465fce67b00&u=%7Cx8O2jgV2RMISbZvm2b09FrpmynuoN27jeqtp1aMfZdU%3D%7C&c1=oP5_e7JVVt0EkjVehxP6aIOIWS-fm2fzhyMXUboeuR1zkGydE3HlloxT1QAbHNNgeH7t9e1IR6mv0biMxm46ZSFdAXZXreJVeP6QwU8IPLUsA32HNafhqgpnKTwmx9RrrJm4CS5Wqj07vNY7UTgDei8AWqc5CGPT2wm7W02JRvgN2kA-oWbWifmmm6EPpqVZijDHDzXwaNgzrfsaEodEmYAjFepGF0mdElHoFUCPKuOtc7mUQijLG0BSS9RhwrCTcAv42KkEQ359Et_eDnQcSt9OAF3bL64QIvLQxt2ekYFNuv3zng03qL0DIHS2bDJwRb3ieUlvZCWHI49OqM5PqoGDpSzdhdwfTE18L6cOOVKqPQ0dPofN4dkSs9IbVGiYlPnjfibL88PwTspYvki2svidSDIa2agQMHVgEof8YY4x4VgPjA8XY-s93ttw_i-RN3lcQn2mGEp6FYmRsyjFEDxHgGfJ0j6U\"></script>"]);
   XCTAssertEqualObjects([NSURL URLWithString:@"https://criteo.com"], mockWebView.loadedBaseURL);
+  OCMVerify([self.integrationRegistry declare:CR_IntegrationStandalone]);
 }
 
 - (void)testWebViewAddedToViewHierarchy {
@@ -148,6 +155,7 @@
   [bannerView loadAd];
 
   OCMVerify([self.criteo getBid:[self expectedCacheAdUnit]]);
+  OCMVerify([self.integrationRegistry declare:CR_IntegrationStandalone]);
 }
 
 // TODO: UITests for "click" on a "real" webview with a real link


### PR DESCRIPTION
- [x] Standalone:
  - `CRBannerView#loadAd`
  - `CRInterstitial#loadAdCRNativeLoader#loadAd`
  - `CRNativeLoader#loadAd`
- [x] InHouse: `Criteo#getBidResponseForAdUnit:CRAdUnit`
- [x] MoPub App Bidding: `Criteo#setBidsForRequest:id withAdUnit:CRAdUnit` with and id of type MPAdView or MPInterstitialAdController
- [x] DFP App Bidding: `Criteo#setBidsForRequest:id withAdUnit:CRAdUnit` with and id of type DFPRequest (or siblings)
- [x] Custom App Bidding: `Criteo#setBidsForRequest:id withAdUnit:CRAdUnit` with and id of type NSMutableDictionary

JIRA: EE-1196