### PR TITLE
[profile-id] Tests fixes

### DIFF
--- a/CriteoPublisherSdk/Tests/IntegrationTests/CRInterstitialTests.m
+++ b/CriteoPublisherSdk/Tests/IntegrationTests/CRInterstitialTests.m
@@ -62,11 +62,10 @@
   self.urlOpener = CR_URLOpenerMock.new;
 
   self.displaySizeInjector = OCMClassMock([CR_DisplaySizeInjector class]);
-  self.integrationRegistry = OCMClassMock([CR_IntegrationRegistry class]);
 
   CR_DependencyProvider *dependencyProvider = CR_DependencyProvider.testing_dependencyProvider;
   dependencyProvider.displaySizeInjector = self.displaySizeInjector;
-  dependencyProvider.integrationRegistry = self.integrationRegistry;
+  self.integrationRegistry = dependencyProvider.integrationRegistry;
 
   self.criteo = OCMPartialMock([Criteo.alloc initWithDependencyProvider:dependencyProvider]);
 }

--- a/CriteoPublisherSdk/Tests/IntegrationTests/CR_FeedbackMessageFunctionalTests.m
+++ b/CriteoPublisherSdk/Tests/IntegrationTests/CR_FeedbackMessageFunctionalTests.m
@@ -52,7 +52,7 @@
           .withListenedNetworkManager
           // We don't want to isolate the tests from the disk
           //.withIsolatedFeedbackStorage
-          .withIsolatedNotificationCenter;
+          .withIsolatedNotificationCenter.withIsolatedIntegrationRegistry;
 
   self.criteo = [[Criteo alloc] initWithDependencyProvider:dependencyProvider];
   self.nsdateMock = OCMClassMock([NSDate class]);

--- a/CriteoPublisherSdk/Tests/PerformanceTests/CR_BidPerformanceTests.m
+++ b/CriteoPublisherSdk/Tests/PerformanceTests/CR_BidPerformanceTests.m
@@ -39,7 +39,7 @@
           .withListenedNetworkManager
           // We don't want to isolate the tests from the disk
           //.withIsolatedFeedbackStorage
-          .withIsolatedNotificationCenter;
+          .withIsolatedNotificationCenter.withIsolatedIntegrationRegistry;
 
   self.criteo = [[Criteo alloc] initWithDependencyProvider:dependencyProvider];
 }

--- a/CriteoPublisherSdk/Tests/UnitTests/CR_HeaderBiddingTests.m
+++ b/CriteoPublisherSdk/Tests/UnitTests/CR_HeaderBiddingTests.m
@@ -31,7 +31,7 @@
 #import "NSString+CriteoUrl.h"
 #import "CR_DisplaySizeInjector.h"
 #import "CR_IntegrationRegistry.h"
-#import "CR_DependencyProvider.h"
+#import "CR_DependencyProvider+Testing.h"
 
 static NSString *const kCpmKey = @"crt_cpm";
 static NSString *const kDictionaryDisplayUrlKey = @"crt_displayUrl";
@@ -87,13 +87,13 @@ typedef NS_ENUM(NSInteger, CR_DeviceOrientation) {
 - (void)setUp {
   self.device = [[CR_DeviceInfoMock alloc] init];
   self.displaySizeInjector = OCMClassMock([CR_DisplaySizeInjector class]);
-  self.integrationRegistry = OCMClassMock([CR_IntegrationRegistry class]);
 
-  CR_DependencyProvider *dependencyProvider = CR_DependencyProvider.new;
+  CR_DependencyProvider *dependencyProvider =
+      CR_DependencyProvider.new.withIsolatedIntegrationRegistry;
   dependencyProvider.deviceInfo = self.device;
   dependencyProvider.displaySizeInjector = self.displaySizeInjector;
-  dependencyProvider.integrationRegistry = self.integrationRegistry;
   self.headerBidding = dependencyProvider.headerBidding;
+  self.integrationRegistry = dependencyProvider.integrationRegistry;
 
   self.adUnit1 = [[CR_CacheAdUnit alloc] initWithAdUnitId:@"adUnit1" width:300 height:250];
   self.bid1 = CR_CdbBidBuilder.new.adUnit(self.adUnit1).build;

--- a/CriteoPublisherSdk/Tests/UnitTests/CriteoTests.m
+++ b/CriteoPublisherSdk/Tests/UnitTests/CriteoTests.m
@@ -36,10 +36,8 @@
 @implementation CriteoTests
 
 - (void)setUp {
-  self.integrationRegistry = OCMClassMock([CR_IntegrationRegistry class]);
-
   CR_DependencyProvider *dependencyProvider = CR_DependencyProvider.testing_dependencyProvider;
-  dependencyProvider.integrationRegistry = self.integrationRegistry;
+  self.integrationRegistry = dependencyProvider.integrationRegistry;
 
   self.criteo = [[Criteo alloc] initWithDependencyProvider:dependencyProvider];
 }

--- a/CriteoPublisherSdk/Tests/UnitTests/Native/CR_NativeLoaderTests.m
+++ b/CriteoPublisherSdk/Tests/UnitTests/Native/CR_NativeLoaderTests.m
@@ -63,12 +63,11 @@
   self.urlOpener = [[CR_URLOpenerMock alloc] init];
   self.networkManagerMock = OCMClassMock([CR_NetworkManager class]);
   self.mediaDownloaderMock = OCMProtocolMock(@protocol(CRMediaDownloader));
-  self.integrationRegistry = OCMClassMock([CR_IntegrationRegistry class]);
 
   CR_DependencyProvider *provider = [CR_DependencyProvider testing_dependencyProvider];
   provider.networkManager = self.networkManagerMock;
   provider.mediaDownloader = self.mediaDownloaderMock;
-  provider.integrationRegistry = self.integrationRegistry;
+  self.integrationRegistry = provider.integrationRegistry;
 
   self.criteo = OCMClassMock([Criteo class]);
   OCMStub([self.criteo dependencyProvider]).andReturn(provider);

--- a/CriteoPublisherSdk/Tests/Utility/Categories/CR_DependencyProvider+Testing.h
+++ b/CriteoPublisherSdk/Tests/Utility/Categories/CR_DependencyProvider+Testing.h
@@ -32,6 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(weak, nonatomic, readonly) CR_DependencyProvider *withListenedNetworkManager;
 @property(weak, nonatomic, readonly) CR_DependencyProvider *withIsolatedNotificationCenter;
 @property(weak, nonatomic, readonly) CR_DependencyProvider *withIsolatedFeedbackStorage;
+@property(weak, nonatomic, readonly) CR_DependencyProvider *withIsolatedIntegrationRegistry;
 
 + (instancetype)testing_dependencyProvider;
 

--- a/CriteoPublisherSdk/Tests/Utility/Categories/CR_DependencyProvider+Testing.m
+++ b/CriteoPublisherSdk/Tests/Utility/Categories/CR_DependencyProvider+Testing.m
@@ -20,6 +20,7 @@
 #import <OCMock/OCMock.h>
 #import "CR_DependencyProvider+Testing.h"
 #import "CR_InMemoryUserDefaults.h"
+#import "CR_IntegrationRegistry.h"
 #import "CR_NetworkManagerSimulator.h"
 #import "CR_NetworkCaptor.h"
 #import "Criteo+Testing.h"
@@ -81,6 +82,13 @@
 
 - (CR_DependencyProvider *)withIsolatedUserDefaults {
   self.userDefaults = [[CR_InMemoryUserDefaults alloc] init];
+  return self;
+}
+
+- (CR_DependencyProvider *)withIsolatedIntegrationRegistry {
+  CR_IntegrationRegistry *mock = OCMClassMock(CR_IntegrationRegistry.class);
+  OCMStub([mock profileId]).andReturn(@42);
+  self.integrationRegistry = mock;
   return self;
 }
 

--- a/CriteoPublisherSdk/Tests/Utility/Categories/CR_DependencyProvider+Testing.m
+++ b/CriteoPublisherSdk/Tests/Utility/Categories/CR_DependencyProvider+Testing.m
@@ -31,7 +31,7 @@
 + (instancetype)testing_dependencyProvider {
   return CR_DependencyProvider.new.withIsolatedUserDefaults.withIsolatedDeviceInfo
       .withWireMockConfiguration.withListenedNetworkManager.withIsolatedNotificationCenter
-      .withIsolatedFeedbackStorage;
+      .withIsolatedFeedbackStorage.withIsolatedIntegrationRegistry;
 }
 
 - (CR_DependencyProvider *)withListenedNetworkManager {


### PR DESCRIPTION
The Feedback functional tests were broken because of profile id introduced changes.
Let's isolate most tests from integration registry.