### PR TITLE
[scripts] Fix archive license

### DIFF
--- a/scripts/base.sh
+++ b/scripts/base.sh
@@ -77,6 +77,7 @@ function crto-fat-build() {
 }
 
 function crto-archive() {
+  cp LICENSE "$BUILD_PATH"
   pushd "$BUILD_PATH"
   crto-echo "Archiving..."
   zip -r "CriteoPublisherSdk.$CRITEO_CONFIGURATION.zip" CriteoPublisherSdk.framework LICENSE


### PR DESCRIPTION
CocoaPods checks LICENSE in archive, raising a warning that prevents releasing otherwise.