### PR TITLE
Handle subclasses of GAM/MoPub objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 - GAM App-Bidding: Support sub classes of GAM objects: `DFPRequest`, `GADRequest`, ...
+- MoPub App-Bidding: Support sub classes of `MPAdView` and `MPInterstitialAdController`.
 --------------------------------------------------------------------------------
 ## Version 3.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Criteo Publisher SDK Changelog
 --------------------------------------------------------------------------------
+## Next
+
+### Features
+- GAM App-Bidding: Support sub classes of GAM objects: `DFPRequest`, `GADRequest`, ...
+--------------------------------------------------------------------------------
 ## Version 3.9.0
 
 ### Features

--- a/CriteoPublisherSdk/Sources/CR_HeaderBidding.m
+++ b/CriteoPublisherSdk/Sources/CR_HeaderBidding.m
@@ -85,10 +85,8 @@
 }
 
 - (BOOL)isMoPubRequest:(id)request {
-  NSString *className = NSStringFromClass([request class]);
-  BOOL result = [className isEqualToString:@"MPAdView"] ||
-                [className isEqualToString:@"MPInterstitialAdController"];
-  return result;
+  return [self is:request kindOfClassByName:@"MPAdView"] ||
+         [self is:request kindOfClassByName:@"MPInterstitialAdController"];
 }
 
 - (BOOL)isCustomRequest:(id)request {

--- a/CriteoPublisherSdk/Sources/CR_HeaderBidding.m
+++ b/CriteoPublisherSdk/Sources/CR_HeaderBidding.m
@@ -75,6 +75,8 @@
   }
 }
 
+#pragma mark - Private
+
 - (void)removeCriteoBidsFromMoPubRequest:(id)adRequest {
   NSAssert([self isMoPubRequest:adRequest], @"Given object isn't from MoPub API: %@", adRequest);
   // For now, this method is a class method because it is used
@@ -89,18 +91,25 @@
   return result;
 }
 
-#pragma mark - Private
-
 - (BOOL)isCustomRequest:(id)request {
   return [request isKindOfClass:NSMutableDictionary.class];
 }
 
 - (BOOL)isDfpRequest:(id)request {
-  NSString *name = NSStringFromClass([request class]);
-  BOOL result = [name isEqualToString:@"DFPRequest"] || [name isEqualToString:@"DFPNRequest"] ||
-                [name isEqualToString:@"DFPORequest"] || [name isEqualToString:@"GADRequest"] ||
-                [name isEqualToString:@"GADORequest"] || [name isEqualToString:@"GADNRequest"];
-  return result;
+  return [self is:request kindOfClassByName:@"DFPRequest"] ||
+         [self is:request kindOfClassByName:@"DFPNRequest"] ||
+         [self is:request kindOfClassByName:@"DFPORequest"] ||
+         [self is:request kindOfClassByName:@"GADRequest"] ||
+         [self is:request kindOfClassByName:@"GADORequest"] ||
+         [self is:request kindOfClassByName:@"GADNRequest"];
+}
+
+- (BOOL)is:(id)request kindOfClassByName:(NSString *)name {
+  Class klass = NSClassFromString(name);
+  if (klass == nil) {
+    return NO;
+  }
+  return [request isKindOfClass:klass];
 }
 
 - (void)addCriteoBidToDictionary:(NSMutableDictionary *)dictionary

--- a/CriteoPublisherSdk/Tests/UnitTests/CR_HeaderBiddingTests.m
+++ b/CriteoPublisherSdk/Tests/UnitTests/CR_HeaderBiddingTests.m
@@ -63,6 +63,24 @@ typedef NS_ENUM(NSInteger, CR_DeviceOrientation) {
 #define CR_AssertEqualDfpString(notDfpStr, dfpStr) \
   XCTAssertEqualObjects([NSString cr_dfpCompatibleString:notDfpStr], dfpStr);
 
+@interface CR_HeaderBidding (Testing)
+
+- (BOOL)isDfpRequest:(id)request;
+
+@end
+
+@interface MyGADRequest : GADRequest
+@end
+
+@implementation MyGADRequest
+@end
+
+@interface MyDFPRequest : DFPRequest
+@end
+
+@implementation MyDFPRequest
+@end
+
 @interface CR_HeaderBiddingTests : XCTestCase
 
 @property(strong, nonatomic) CR_DeviceInfoMock *device;
@@ -159,6 +177,46 @@ typedef NS_ENUM(NSInteger, CR_DeviceOrientation) {
 }
 
 #pragma mark - Google Ad
+
+- (void)testIsDFPRequest_GivenGADRequest_ReturnTrue {
+  id request = GADRequest.new;
+
+  BOOL isDfpRequest = [self.headerBidding isDfpRequest:request];
+
+  XCTAssertTrue(isDfpRequest);
+}
+
+- (void)testIsDFPRequest_GivenSubClassOfGADRequest_ReturnTrue {
+  id request = MyGADRequest.new;
+
+  BOOL isDfpRequest = [self.headerBidding isDfpRequest:request];
+
+  XCTAssertTrue(isDfpRequest);
+}
+
+- (void)testIsDFPRequest_GivenDFPRequest_ReturnTrue {
+  id request = DFPRequest.new;
+
+  BOOL isDfpRequest = [self.headerBidding isDfpRequest:request];
+
+  XCTAssertTrue(isDfpRequest);
+}
+
+- (void)testIsDFPRequest_GivenSubClassOfDFPRequest_ReturnTrue {
+  id request = MyDFPRequest.new;
+
+  BOOL isDfpRequest = [self.headerBidding isDfpRequest:request];
+
+  XCTAssertTrue(isDfpRequest);
+}
+
+- (void)testIsDFPRequest_GivenUnrelatedObject_ReturnFalse {
+  id request = NSObject.new;
+
+  BOOL isDfpRequest = [self.headerBidding isDfpRequest:request];
+
+  XCTAssertFalse(isDfpRequest);
+}
 
 - (void)testGADRequest {
   GADRequest *request = [[GADRequest alloc] init];

--- a/CriteoPublisherSdk/Tests/UnitTests/CR_HeaderBiddingTests.m
+++ b/CriteoPublisherSdk/Tests/UnitTests/CR_HeaderBiddingTests.m
@@ -66,6 +66,7 @@ typedef NS_ENUM(NSInteger, CR_DeviceOrientation) {
 @interface CR_HeaderBidding (Testing)
 
 - (BOOL)isDfpRequest:(id)request;
+- (BOOL)isMoPubRequest:(id)request;
 
 @end
 
@@ -79,6 +80,18 @@ typedef NS_ENUM(NSInteger, CR_DeviceOrientation) {
 @end
 
 @implementation MyDFPRequest
+@end
+
+@interface MyMPAdView : MPAdView
+@end
+
+@implementation MyMPAdView
+@end
+
+@interface MyMPInterstitialAdController : MPInterstitialAdController
+@end
+
+@implementation MyMPInterstitialAdController
 @end
 
 @interface CR_HeaderBiddingTests : XCTestCase
@@ -315,6 +328,46 @@ typedef NS_ENUM(NSInteger, CR_DeviceOrientation) {
 }
 
 #pragma mark - Mopub
+
+- (void)testIsMoPubRequest_GivenMoPubView_ReturnTrue {
+  id request = MPAdView.new;
+
+  BOOL isMoPubRequest = [self.headerBidding isMoPubRequest:request];
+
+  XCTAssertTrue(isMoPubRequest);
+}
+
+- (void)testIsMoPubRequest_GivenSubClassOfMoPubView_ReturnTrue {
+  id request = MyMPAdView.new;
+
+  BOOL isMoPubRequest = [self.headerBidding isMoPubRequest:request];
+
+  XCTAssertTrue(isMoPubRequest);
+}
+
+- (void)testIsMoPubRequest_GivenMoPubInterstitial_ReturnTrue {
+  id request = MPInterstitialAdController.new;
+
+  BOOL isMoPubRequest = [self.headerBidding isMoPubRequest:request];
+
+  XCTAssertTrue(isMoPubRequest);
+}
+
+- (void)testIsMoPubRequest_GivenSubClassOfMoPubInterstitialRequest_ReturnTrue {
+  id request = MyMPInterstitialAdController.new;
+
+  BOOL isMoPubRequest = [self.headerBidding isMoPubRequest:request];
+
+  XCTAssertTrue(isMoPubRequest);
+}
+
+- (void)testIsMoPubRequest_GivenUnrelatedObject_ReturnFalse {
+  id request = NSObject.new;
+
+  BOOL isMoPubRequest = [self.headerBidding isMoPubRequest:request];
+
+  XCTAssertFalse(isMoPubRequest);
+}
 
 - (void)testMPInterstitialAdController {
   MPInterstitialAdController *controller = [MPInterstitialAdController new];


### PR DESCRIPTION
On Android header bidding integrations, we check the class name to decide the integration type and properly insert keywords by using string equality, e.g. "MOAdView" for MoPub.

Some publishers may extend these classes and use subclasses of GAM / MoPub objects, currently we can't set keywords with these subclasses.

We'd like to support both the original MoPub objects and their subclasses.

JIRA: EE-1114