### PR TITLE
[Criteo] Document class

### DIFF
--- a/CriteoPublisherSdk/Sources/Criteo.h
+++ b/CriteoPublisherSdk/Sources/Criteo.h
@@ -25,22 +25,46 @@
 #import <CriteoPublisherSdk/CRBidResponse.h>
 
 NS_ASSUME_NONNULL_BEGIN
+
 @interface Criteo : NSObject
 
-/* @abstract Use sharedInstance */
+/**
+ * Use sharedCriteo singleton accessor, do not init your own instance
+ * Note: Initialization is expected through registerCriteoPublisherId:
+ */
 - (instancetype)init NS_UNAVAILABLE;
+
+/**
+ * Criteo shared instance singleton
+ * Note: Initialization is expected through registerCriteoPublisherId:
+ * @return The Criteo singleton
+ */
 + (nonnull instancetype)sharedCriteo;
 
-/** @abstract Set a custom opt-out/opt-in with same behaviour as the CCPA (US Privacy). */
+/** Set a custom opt-out/opt-in with same behaviour as the CCPA (US Privacy). */
 - (void)setUsPrivacyOptOut:(BOOL)usPrivacyOptOut;
-/** @abstract Set the privacy consent string owned by the Mopub SDK. */
+/** Set the privacy consent string owned by the Mopub SDK. */
 - (void)setMopubConsent:(NSString *)mopubConsent;
 
+/**
+ * Initialize Criteo singleton
+ * @param criteoPublisherId Publisher Identifier
+ * @param adUnits AdUnits array
+ */
 - (void)registerCriteoPublisherId:(NSString *)criteoPublisherId
                       withAdUnits:(NSArray<CRAdUnit *> *)adUnits;
-
+/**
+ * Header bidding API, enrich your request with Criteo metadata
+ * @param request The request to enrich, supports GAM and MoPub
+ * @param adUnit The adUnit related to request
+ */
 - (void)setBidsForRequest:(id)request withAdUnit:(CRAdUnit *)adUnit;
 
+/**
+ * In-House bidding API, provide direct access to a Criteo bid
+ * @param adUnit The adUnit related to request
+ * @return Bid Response that can later be used for displaying ads
+ */
 - (CRBidResponse *)getBidResponseForAdUnit:(CRAdUnit *)adUnit;
 
 @end


### PR DESCRIPTION
It would be nice at some point for public APIs to be fully documented for IDE hints or html generation.
`Criteo` class is a good start, also this PR is a way to discuss the v4 API future.