### PR TITLE
Move Cassette from cocoapods dependency to SDK Source include

### DIFF
--- a/CriteoPublisherSdk/CriteoPublisherSdk.xcodeproj/project.pbxproj
+++ b/CriteoPublisherSdk/CriteoPublisherSdk.xcodeproj/project.pbxproj
@@ -7,11 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		198CD4A32B7B46B6F1FAC786 /* CASBoundedFileObjectQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = 198CDC91DC407C38A0C16DA1 /* CASBoundedFileObjectQueue.h */; };
+		198CD4A32B7B46B6F1FAC786 /* CR_CASBoundedFileObjectQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = 198CDC91DC407C38A0C16DA1 /* CR_CASBoundedFileObjectQueue.h */; };
 		198CD5E258B0B62164C092E6 /* CRNativeAdTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 198CD3F7C2A1974769B2CE1C /* CRNativeAdTests.m */; };
 		198CD78A8C6C3B1E04A092AF /* CR_FeedbackConsentGuard.h in Headers */ = {isa = PBXBuildFile; fileRef = 198CD3A94D942C1D06E438AC /* CR_FeedbackConsentGuard.h */; };
 		198CD81669DB4102F98AA7F2 /* CR_FeedbackConsentGuard.m in Sources */ = {isa = PBXBuildFile; fileRef = 198CD92618033AC3E44B0073 /* CR_FeedbackConsentGuard.m */; };
-		198CDFA1D272C69DA0CE470D /* CASBoundedFileObjectQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = 198CDC22999EF696C16309C5 /* CASBoundedFileObjectQueue.m */; };
+		198CDFA1D272C69DA0CE470D /* CR_CASBoundedFileObjectQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = 198CDC22999EF696C16309C5 /* CR_CASBoundedFileObjectQueue.m */; };
 		25BD5B5B2220D16D004DE311 /* CriteoPublisherSdk.h in Headers */ = {isa = PBXBuildFile; fileRef = 25BD5B592220D16D004DE311 /* CriteoPublisherSdk.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		25BD5B5F2220D183004DE311 /* CR_AppEvents.m in Sources */ = {isa = PBXBuildFile; fileRef = E12A7F6E220A20C3002B4548 /* CR_AppEvents.m */; };
 		25BD5B622220D1A8004DE311 /* CR_BidManager.m in Sources */ = {isa = PBXBuildFile; fileRef = E1F273BA21C9733800A2FBFA /* CR_BidManager.m */; };
@@ -42,11 +42,24 @@
 		4660614324754E8100690E27 /* CR_SafeMediaDownloader.h in Headers */ = {isa = PBXBuildFile; fileRef = 4660614124754E8100690E27 /* CR_SafeMediaDownloader.h */; };
 		4660614424754E8100690E27 /* CR_SafeMediaDownloader.m in Sources */ = {isa = PBXBuildFile; fileRef = 4660614224754E8100690E27 /* CR_SafeMediaDownloader.m */; };
 		4668FEF52459BD3A00D207AE /* CRNativeLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = 4668FEF12459BD1000D207AE /* CRNativeLoader.m */; };
-		467D34CA243E060A00852B4D /* CASBoundedFileObjectQueueTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 467D34C9243E060A00852B4D /* CASBoundedFileObjectQueueTests.m */; };
+		4672E1DF251CDE02009F39EF /* CR_CASQueueFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 4672E1D1251CDE02009F39EF /* CR_CASQueueFile.m */; };
+		4672E1E0251CDE02009F39EF /* CR_CASObjectQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = 4672E1D2251CDE02009F39EF /* CR_CASObjectQueue.m */; };
+		4672E1E1251CDE02009F39EF /* CR_CASQueueFile.h in Headers */ = {isa = PBXBuildFile; fileRef = 4672E1D3251CDE02009F39EF /* CR_CASQueueFile.h */; };
+		4672E1E2251CDE02009F39EF /* CR_CASError.m in Sources */ = {isa = PBXBuildFile; fileRef = 4672E1D4251CDE02009F39EF /* CR_CASError.m */; };
+		4672E1E3251CDE02009F39EF /* CR_CASFileObjectQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = 4672E1D5251CDE02009F39EF /* CR_CASFileObjectQueue.h */; };
+		4672E1E4251CDE02009F39EF /* CR_CASInMemoryObjectQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = 4672E1D6251CDE02009F39EF /* CR_CASInMemoryObjectQueue.h */; };
+		4672E1E5251CDE02009F39EF /* Cassette.h in Headers */ = {isa = PBXBuildFile; fileRef = 4672E1D7251CDE02009F39EF /* Cassette.h */; };
+		4672E1E6251CDE02009F39EF /* CR_CASObjectQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = 4672E1D8251CDE02009F39EF /* CR_CASObjectQueue.h */; };
+		4672E1E7251CDE02009F39EF /* CR_CASPrivateConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 4672E1D9251CDE02009F39EF /* CR_CASPrivateConstants.h */; };
+		4672E1E8251CDE02009F39EF /* CR_CASInMemoryObjectQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = 4672E1DA251CDE02009F39EF /* CR_CASInMemoryObjectQueue.m */; };
+		4672E1E9251CDE03009F39EF /* CR_CASError.h in Headers */ = {isa = PBXBuildFile; fileRef = 4672E1DB251CDE02009F39EF /* CR_CASError.h */; };
+		4672E1EA251CDE03009F39EF /* CR_CASQueueFileElement.h in Headers */ = {isa = PBXBuildFile; fileRef = 4672E1DC251CDE02009F39EF /* CR_CASQueueFileElement.h */; };
+		4672E1EB251CDE03009F39EF /* CR_CASFileObjectQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = 4672E1DD251CDE02009F39EF /* CR_CASFileObjectQueue.m */; };
+		4672E1EC251CDE03009F39EF /* CR_CASQueueFileElement.m in Sources */ = {isa = PBXBuildFile; fileRef = 4672E1DE251CDE02009F39EF /* CR_CASQueueFileElement.m */; };
+		467D34CA243E060A00852B4D /* CR_CASBoundedFileObjectQueueTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 467D34C9243E060A00852B4D /* CR_CASBoundedFileObjectQueueTests.m */; };
 		46813BEE2472E39000CD8E59 /* CRMediaDownloader.h in Headers */ = {isa = PBXBuildFile; fileRef = 46813BEC2472E39000CD8E59 /* CRMediaDownloader.h */; };
 		46813BF32472EA5D00CD8E59 /* CR_DefaultMediaDownloader.m in Sources */ = {isa = PBXBuildFile; fileRef = 46813BF12472EA5D00CD8E59 /* CR_DefaultMediaDownloader.m */; };
 		469301CA24740289006F8D82 /* CR_ImpressionDetector.m in Sources */ = {isa = PBXBuildFile; fileRef = 469301C824740289006F8D82 /* CR_ImpressionDetector.m */; };
-		46AC066B24619FA400796AAA /* libCassette.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 547287842411075D00B62235 /* libCassette.a */; };
 		46AD5CF5245B003D00199315 /* CR_NativeLoaderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 46AD5CF4245B003D00199315 /* CR_NativeLoaderTests.m */; };
 		46B6115724C9DBD4002896F8 /* CRConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 46E8A70324B74D69007103B9 /* CRConstants.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		46B9780E243782A50061FC24 /* CR_UniqueIdGenerator.m in Sources */ = {isa = PBXBuildFile; fileRef = 46240E0C2434BB4F001425AB /* CR_UniqueIdGenerator.m */; };
@@ -138,8 +151,8 @@
 		6540470F22581D32009235A1 /* MockWKWebView.m in Sources */ = {isa = PBXBuildFile; fileRef = 6540470E22581D32009235A1 /* MockWKWebView.m */; };
 		654858AA226538D500DC471A /* CRInterstitial.m in Sources */ = {isa = PBXBuildFile; fileRef = 654858A6226538D500DC471A /* CRInterstitial.m */; };
 		65E3A5742270CB7A004156E9 /* CR_InterstitialViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 65E3A5702270CB7A004156E9 /* CR_InterstitialViewController.m */; };
-		7D00672D243CD6F900E5D50D /* CASObjectQueue+ArraySet.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D00672A243CD6F900E5D50D /* CASObjectQueue+ArraySet.m */; };
-		7D00672F243CD6F900E5D50D /* CASObjectQueue+ArraySet.h in Headers */ = {isa = PBXBuildFile; fileRef = 7D00672B243CD6F900E5D50D /* CASObjectQueue+ArraySet.h */; };
+		7D00672D243CD6F900E5D50D /* CR_CASObjectQueue+ArraySet.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D00672A243CD6F900E5D50D /* CR_CASObjectQueue+ArraySet.m */; };
+		7D00672F243CD6F900E5D50D /* CR_CASObjectQueue+ArraySet.h in Headers */ = {isa = PBXBuildFile; fileRef = 7D00672B243CD6F900E5D50D /* CR_CASObjectQueue+ArraySet.h */; };
 		7D006733243DB74B00E5D50D /* CR_FeedbackMessageFunctionalTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D006732243DB74B00E5D50D /* CR_FeedbackMessageFunctionalTests.m */; };
 		7D00897023EAD19C00BA8F96 /* CRBannerViewDelegateMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D00896F23EAD19C00BA8F96 /* CRBannerViewDelegateMock.m */; };
 		7D03F0FF23F18ECF00CB5D8B /* CRNativeAd.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D03F0FB23F18ECF00CB5D8B /* CRNativeAd.m */; };
@@ -307,8 +320,8 @@
 		198CD3F7C2A1974769B2CE1C /* CRNativeAdTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CRNativeAdTests.m; sourceTree = "<group>"; };
 		198CD49D6226F38F4FEACE9E /* CR_DeviceInfo+Testing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "CR_DeviceInfo+Testing.h"; sourceTree = "<group>"; };
 		198CD92618033AC3E44B0073 /* CR_FeedbackConsentGuard.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CR_FeedbackConsentGuard.m; sourceTree = "<group>"; };
-		198CDC22999EF696C16309C5 /* CASBoundedFileObjectQueue.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CASBoundedFileObjectQueue.m; sourceTree = "<group>"; };
-		198CDC91DC407C38A0C16DA1 /* CASBoundedFileObjectQueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CASBoundedFileObjectQueue.h; sourceTree = "<group>"; };
+		198CDC22999EF696C16309C5 /* CR_CASBoundedFileObjectQueue.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CR_CASBoundedFileObjectQueue.m; sourceTree = "<group>"; };
+		198CDC91DC407C38A0C16DA1 /* CR_CASBoundedFileObjectQueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CR_CASBoundedFileObjectQueue.h; sourceTree = "<group>"; };
 		1CDD7544323F61638E0E8B7F /* libPods-CriteoPublisherSdk.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-CriteoPublisherSdk.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		25022DE4220A3F0300FF8ACE /* CR_NetworkManagerDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CR_NetworkManagerDelegate.h; sourceTree = "<group>"; };
 		25022DE5220A709000FF8ACE /* Criteo+Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Criteo+Internal.h"; sourceTree = "<group>"; };
@@ -341,7 +354,21 @@
 		4660614224754E8100690E27 /* CR_SafeMediaDownloader.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CR_SafeMediaDownloader.m; sourceTree = "<group>"; };
 		4668FEEF2459BD1000D207AE /* CRNativeLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CRNativeLoader.h; sourceTree = "<group>"; };
 		4668FEF12459BD1000D207AE /* CRNativeLoader.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CRNativeLoader.m; sourceTree = "<group>"; };
-		467D34C9243E060A00852B4D /* CASBoundedFileObjectQueueTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CASBoundedFileObjectQueueTests.m; sourceTree = "<group>"; };
+		4672E1D1251CDE02009F39EF /* CR_CASQueueFile.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CR_CASQueueFile.m; sourceTree = "<group>"; };
+		4672E1D2251CDE02009F39EF /* CR_CASObjectQueue.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CR_CASObjectQueue.m; sourceTree = "<group>"; };
+		4672E1D3251CDE02009F39EF /* CR_CASQueueFile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CR_CASQueueFile.h; sourceTree = "<group>"; };
+		4672E1D4251CDE02009F39EF /* CR_CASError.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CR_CASError.m; sourceTree = "<group>"; };
+		4672E1D5251CDE02009F39EF /* CR_CASFileObjectQueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CR_CASFileObjectQueue.h; sourceTree = "<group>"; };
+		4672E1D6251CDE02009F39EF /* CR_CASInMemoryObjectQueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CR_CASInMemoryObjectQueue.h; sourceTree = "<group>"; };
+		4672E1D7251CDE02009F39EF /* Cassette.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Cassette.h; sourceTree = "<group>"; };
+		4672E1D8251CDE02009F39EF /* CR_CASObjectQueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CR_CASObjectQueue.h; sourceTree = "<group>"; };
+		4672E1D9251CDE02009F39EF /* CR_CASPrivateConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CR_CASPrivateConstants.h; sourceTree = "<group>"; };
+		4672E1DA251CDE02009F39EF /* CR_CASInMemoryObjectQueue.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CR_CASInMemoryObjectQueue.m; sourceTree = "<group>"; };
+		4672E1DB251CDE02009F39EF /* CR_CASError.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CR_CASError.h; sourceTree = "<group>"; };
+		4672E1DC251CDE02009F39EF /* CR_CASQueueFileElement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CR_CASQueueFileElement.h; sourceTree = "<group>"; };
+		4672E1DD251CDE02009F39EF /* CR_CASFileObjectQueue.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CR_CASFileObjectQueue.m; sourceTree = "<group>"; };
+		4672E1DE251CDE02009F39EF /* CR_CASQueueFileElement.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CR_CASQueueFileElement.m; sourceTree = "<group>"; };
+		467D34C9243E060A00852B4D /* CR_CASBoundedFileObjectQueueTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CR_CASBoundedFileObjectQueueTests.m; sourceTree = "<group>"; };
 		46813BEC2472E39000CD8E59 /* CRMediaDownloader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CRMediaDownloader.h; sourceTree = "<group>"; };
 		46813BF02472EA5D00CD8E59 /* CR_DefaultMediaDownloader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CR_DefaultMediaDownloader.h; sourceTree = "<group>"; };
 		46813BF12472EA5D00CD8E59 /* CR_DefaultMediaDownloader.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CR_DefaultMediaDownloader.m; sourceTree = "<group>"; };
@@ -402,7 +429,6 @@
 		54680B7523969D5C00DB5A37 /* CR_IntegrationsTestBase.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CR_IntegrationsTestBase.m; sourceTree = "<group>"; };
 		54680B7723969D7E00DB5A37 /* CR_IntegrationsTestBase.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CR_IntegrationsTestBase.h; sourceTree = "<group>"; };
 		54680B7823969E7300DB5A37 /* CR_MopubBannerFunctionalTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CR_MopubBannerFunctionalTests.m; sourceTree = "<group>"; };
-		547287842411075D00B62235 /* libCassette.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libCassette.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		547BC941230650B500FB8599 /* CR_BidFetchTracker.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CR_BidFetchTracker.h; sourceTree = "<group>"; };
 		547BC942230650B500FB8599 /* CR_BidFetchTracker.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CR_BidFetchTracker.m; sourceTree = "<group>"; };
 		548AFCAC23B1113C003C9C29 /* CR_StandaloneBannerFunctionalTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CR_StandaloneBannerFunctionalTests.m; sourceTree = "<group>"; };
@@ -461,8 +487,8 @@
 		6549B552228389930078F068 /* CRInterstitialDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CRInterstitialDelegate.h; sourceTree = "<group>"; };
 		65E3A56F2270CB7A004156E9 /* CR_InterstitialViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CR_InterstitialViewController.h; sourceTree = "<group>"; };
 		65E3A5702270CB7A004156E9 /* CR_InterstitialViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CR_InterstitialViewController.m; sourceTree = "<group>"; };
-		7D00672A243CD6F900E5D50D /* CASObjectQueue+ArraySet.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "CASObjectQueue+ArraySet.m"; sourceTree = "<group>"; };
-		7D00672B243CD6F900E5D50D /* CASObjectQueue+ArraySet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "CASObjectQueue+ArraySet.h"; sourceTree = "<group>"; };
+		7D00672A243CD6F900E5D50D /* CR_CASObjectQueue+ArraySet.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "CR_CASObjectQueue+ArraySet.m"; sourceTree = "<group>"; };
+		7D00672B243CD6F900E5D50D /* CR_CASObjectQueue+ArraySet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "CR_CASObjectQueue+ArraySet.h"; sourceTree = "<group>"; };
 		7D006732243DB74B00E5D50D /* CR_FeedbackMessageFunctionalTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CR_FeedbackMessageFunctionalTests.m; sourceTree = "<group>"; };
 		7D00896E23EAD19B00BA8F96 /* CRBannerViewDelegateMock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CRBannerViewDelegateMock.h; sourceTree = "<group>"; };
 		7D00896F23EAD19C00BA8F96 /* CRBannerViewDelegateMock.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CRBannerViewDelegateMock.m; sourceTree = "<group>"; };
@@ -705,7 +731,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				90D0C9A36EF9136F4CC9E877 /* libPods-CriteoPublisherSdk.a in Frameworks */,
-				46AC066B24619FA400796AAA /* libCassette.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -796,6 +821,27 @@
 			path = Network;
 			sourceTree = "<group>";
 		};
+		4672E1A9251CDDF0009F39EF /* Cassette */ = {
+			isa = PBXGroup;
+			children = (
+				4672E1D7251CDE02009F39EF /* Cassette.h */,
+				4672E1DB251CDE02009F39EF /* CR_CASError.h */,
+				4672E1D4251CDE02009F39EF /* CR_CASError.m */,
+				4672E1D5251CDE02009F39EF /* CR_CASFileObjectQueue.h */,
+				4672E1DD251CDE02009F39EF /* CR_CASFileObjectQueue.m */,
+				4672E1D6251CDE02009F39EF /* CR_CASInMemoryObjectQueue.h */,
+				4672E1DA251CDE02009F39EF /* CR_CASInMemoryObjectQueue.m */,
+				4672E1D8251CDE02009F39EF /* CR_CASObjectQueue.h */,
+				4672E1D2251CDE02009F39EF /* CR_CASObjectQueue.m */,
+				4672E1D9251CDE02009F39EF /* CR_CASPrivateConstants.h */,
+				4672E1D3251CDE02009F39EF /* CR_CASQueueFile.h */,
+				4672E1D1251CDE02009F39EF /* CR_CASQueueFile.m */,
+				4672E1DC251CDE02009F39EF /* CR_CASQueueFileElement.h */,
+				4672E1DE251CDE02009F39EF /* CR_CASQueueFileElement.m */,
+			);
+			path = Cassette;
+			sourceTree = "<group>";
+		};
 		46C87E6A244053930022978C /* Feedback */ = {
 			isa = PBXGroup;
 			children = (
@@ -803,7 +849,7 @@
 				54FE074223FEED2C0035A026 /* CR_FeedbackMessageTests.swift */,
 				5E065DD39102A6790D4ADABA /* CR_FeedbackStorageTests.swift */,
 				46240E132434BB91001425AB /* CR_UniqueIdGeneratorTests.swift */,
-				467D34C9243E060A00852B4D /* CASBoundedFileObjectQueueTests.m */,
+				467D34C9243E060A00852B4D /* CR_CASBoundedFileObjectQueueTests.m */,
 				46C87E6B24405B2A0022978C /* CR_DefaultFileManipulatorTests.swift */,
 				C07ABBA46FCA43B62B82A2A0 /* CR_FeedbackControllerTests.m */,
 				4618D0A92507D06E00D95689 /* CR_FeedbackConsentGuardTests.m */,
@@ -815,10 +861,10 @@
 		542B05F523FD97380086A942 /* Feedback */ = {
 			isa = PBXGroup;
 			children = (
-				7D00672B243CD6F900E5D50D /* CASObjectQueue+ArraySet.h */,
-				7D00672A243CD6F900E5D50D /* CASObjectQueue+ArraySet.m */,
-				198CDC91DC407C38A0C16DA1 /* CASBoundedFileObjectQueue.h */,
-				198CDC22999EF696C16309C5 /* CASBoundedFileObjectQueue.m */,
+				7D00672B243CD6F900E5D50D /* CR_CASObjectQueue+ArraySet.h */,
+				7D00672A243CD6F900E5D50D /* CR_CASObjectQueue+ArraySet.m */,
+				198CDC91DC407C38A0C16DA1 /* CR_CASBoundedFileObjectQueue.h */,
+				198CDC22999EF696C16309C5 /* CR_CASBoundedFileObjectQueue.m */,
 				54C24BD624067FEE00DD9839 /* CR_DefaultFileManipulator.h */,
 				54C24BD724067FEE00DD9839 /* CR_DefaultFileManipulator.m */,
 				54C24BC824040F2400DD9839 /* CR_FeedbackFileManager.h */,
@@ -906,7 +952,6 @@
 		58922C790615A11D1E6D635B /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				547287842411075D00B62235 /* libCassette.a */,
 				1CDD7544323F61638E0E8B7F /* libPods-CriteoPublisherSdk.a */,
 				92039F91AE1122C08CF8EC36 /* libPods-CriteoPublisherSdkTests.a */,
 			);
@@ -1403,6 +1448,7 @@
 				DF367C84232971810044807B /* CRNativeAdUnit.h */,
 				DF367C85232971810044807B /* CRNativeAdUnit.m */,
 				E12A7F6C220A1D20002B4548 /* AppEvents */,
+				4672E1A9251CDDF0009F39EF /* Cassette */,
 				258821D622000D3B00398E9F /* Configuration */,
 				542B05F523FD97380086A942 /* Feedback */,
 				7D93A61523FC3286007E8B30 /* DataConsent */,
@@ -1448,15 +1494,18 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4672E1E3251CDE02009F39EF /* CR_CASFileObjectQueue.h in Headers */,
 				53BDFDC622EB9F7C0051EB40 /* CR_BidManagerHelper.h in Headers */,
 				543442FC2285F4A600805343 /* CRBannerViewDelegate.h in Headers */,
 				25BD5B682220D1D2004DE311 /* Criteo.h in Headers */,
+				4672E1E5251CDE02009F39EF /* Cassette.h in Headers */,
 				5397C0B522A0AA8500BC72FE /* CRInterstitialAdUnit.h in Headers */,
 				7DDEF65E242CE06300BC129F /* CR_GdprSerializer.h in Headers */,
 				46B6115724C9DBD4002896F8 /* CRConstants.h in Headers */,
 				7DB899DC2400126800948230 /* NSString+GDPR.h in Headers */,
 				7D1A17CE242A796600816D32 /* CR_GdprVersion.h in Headers */,
 				5397C0AF22A0AA3D00BC72FE /* CRAdUnit.h in Headers */,
+				4672E1E4251CDE02009F39EF /* CR_CASInMemoryObjectQueue.h in Headers */,
 				5472877C2411043500B62235 /* CR_DefaultFileManipulator.h in Headers */,
 				542FCFAA242B6324000D9DA9 /* CR_CdbRequest.h in Headers */,
 				547287822411044200B62235 /* CR_FeedbackStorage.h in Headers */,
@@ -1465,7 +1514,8 @@
 				54658897228C6DB1009746E0 /* CRInterstitialDelegate.h in Headers */,
 				7D167014246D4D5F0097880F /* CR_HeaderBidding.h in Headers */,
 				650915FD225565E6001D6673 /* CRBannerView.h in Headers */,
-				7D00672F243CD6F900E5D50D /* CASObjectQueue+ArraySet.h in Headers */,
+				4672E1E6251CDE02009F39EF /* CR_CASObjectQueue.h in Headers */,
+				7D00672F243CD6F900E5D50D /* CR_CASObjectQueue+ArraySet.h in Headers */,
 				DF367C8A232974210044807B /* CRNativeAdUnit.h in Headers */,
 				7D4B4A8B24191E8E00E1E241 /* CR_ApiQueryKeys.h in Headers */,
 				25BD5B5B2220D16D004DE311 /* CriteoPublisherSdk.h in Headers */,
@@ -1479,17 +1529,21 @@
 				4660614324754E8100690E27 /* CR_SafeMediaDownloader.h in Headers */,
 				7D80F6202406B18F005B7BA3 /* CR_Gdpr.h in Headers */,
 				4642C9C624CAD93E0080AC4F /* CR_IntegrationRegistry.h in Headers */,
+				4672E1E1251CDE02009F39EF /* CR_CASQueueFile.h in Headers */,
 				542FCFB4242D08EE000D9DA9 /* CR_FeedbacksSerializer.h in Headers */,
 				547287802411043E00B62235 /* CR_FeedbackMessage.h in Headers */,
 				547287882411096200B62235 /* CR_FeedbackStorage+MessageUpdating.h in Headers */,
 				46507F82246C2F6900B1DA78 /* CRNativeAdView.h in Headers */,
+				4672E1EA251CDE03009F39EF /* CR_CASQueueFileElement.h in Headers */,
 				46813BEE2472E39000CD8E59 /* CRMediaDownloader.h in Headers */,
 				7DFB2B0F247E5C67007CDFF3 /* CR_URLOpening.h in Headers */,
+				4672E1E9251CDE03009F39EF /* CR_CASError.h in Headers */,
 				53CA0F9622AB0ABD0098F96C /* CRBidResponse.h in Headers */,
 				7D58583023E1F1EC0039AC56 /* CR_ThreadManager.h in Headers */,
 				5E0658FBA75D85CA465F4A37 /* CR_FeedbackStorage+Internal.h in Headers */,
+				4672E1E7251CDE02009F39EF /* CR_CASPrivateConstants.h in Headers */,
 				46D5C3C3245AD3B200818D37 /* CRNativeLoader.h in Headers */,
-				198CD4A32B7B46B6F1FAC786 /* CASBoundedFileObjectQueue.h in Headers */,
+				198CD4A32B7B46B6F1FAC786 /* CR_CASBoundedFileObjectQueue.h in Headers */,
 				C07ABD881B3EF50E277BBEAC /* CR_FeedbackFeatureGuard.h in Headers */,
 				C07ABE08CDD58B26FFCCBCE1 /* NSUserDefaults+CR_Config.h in Headers */,
 				C07AB6C51EDDDE87A80D2666 /* CRMediaContent.h in Headers */,
@@ -1713,10 +1767,12 @@
 				DF367CBB232B397F0044807B /* CR_NativeAssets.m in Sources */,
 				7D3E427023915E7900BAF673 /* NSUserDefaults+Criteo.m in Sources */,
 				53D6429822C2C615005791D4 /* CR_TokenCache.m in Sources */,
+				4672E1E2251CDE02009F39EF /* CR_CASError.m in Sources */,
 				5496876022A5C774007D2578 /* CR_AdUnitHelper.m in Sources */,
 				25BD5B692220D1D9004DE311 /* Criteo.m in Sources */,
 				25BD5B622220D1A8004DE311 /* CR_BidManager.m in Sources */,
 				5470B17123A3BC6600C2B003 /* CR_TargetingKeys.m in Sources */,
+				4672E1E8251CDE02009F39EF /* CR_CASInMemoryObjectQueue.m in Sources */,
 				5397C0B322A0AA6C00BC72FE /* CRInterstitialAdUnit.m in Sources */,
 				46B9780E243782A50061FC24 /* CR_UniqueIdGenerator.m in Sources */,
 				4660614424754E8100690E27 /* CR_SafeMediaDownloader.m in Sources */,
@@ -1730,6 +1786,7 @@
 				545A39A622A8210A00648957 /* NSError+Criteo.m in Sources */,
 				25BD5B652220D1BB004DE311 /* CR_Config.m in Sources */,
 				46DD2E64250698B500EEBBD0 /* NSString+Tcf.m in Sources */,
+				4672E1E0251CDE02009F39EF /* CR_CASObjectQueue.m in Sources */,
 				5472877F2411043C00B62235 /* CR_FeedbackFileManager.m in Sources */,
 				654858AA226538D500DC471A /* CRInterstitial.m in Sources */,
 				46813BF32472EA5D00CD8E59 /* CR_DefaultMediaDownloader.m in Sources */,
@@ -1739,10 +1796,11 @@
 				7D4B4A8A24191E8900E1E241 /* CR_ApiQueryKeys.m in Sources */,
 				5397C0B122A0AA6600BC72FE /* CR_CacheAdUnit.m in Sources */,
 				25BD5B6F2220D209004DE311 /* Logging.m in Sources */,
-				7D00672D243CD6F900E5D50D /* CASObjectQueue+ArraySet.m in Sources */,
+				7D00672D243CD6F900E5D50D /* CR_CASObjectQueue+ArraySet.m in Sources */,
 				25BD5B6B2220D1E6004DE311 /* CR_ApiHandler.m in Sources */,
 				465E9172246C406700227D29 /* CR_AdChoice.m in Sources */,
 				542FCFB6242D08EE000D9DA9 /* CR_FeedbacksSerializer.m in Sources */,
+				4672E1EC251CDE03009F39EF /* CR_CASQueueFileElement.m in Sources */,
 				7D3E426F23915E4200BAF673 /* CR_DependencyProvider.m in Sources */,
 				25BD5B6C2220D1EC004DE311 /* CR_CdbResponse.m in Sources */,
 				5397C0B222A0AA6900BC72FE /* CRBannerAdUnit.m in Sources */,
@@ -1761,6 +1819,7 @@
 				7DDEF660242CE06300BC129F /* CR_GdprSerializer.m in Sources */,
 				53CA0F9122AB0A730098F96C /* CRBidToken.m in Sources */,
 				53CA0F8122AAE3C20098F96C /* CRBidResponse.m in Sources */,
+				4672E1EB251CDE03009F39EF /* CR_CASFileObjectQueue.m in Sources */,
 				53BDFDC822EB9F7C0051EB40 /* CR_BidManagerHelper.m in Sources */,
 				DF367CA5232B20F90044807B /* CR_NativeAdvertiser.m in Sources */,
 				547BC945230650BB00FB8599 /* CR_BidFetchTracker.m in Sources */,
@@ -1773,7 +1832,7 @@
 				650915F82255622E001D6673 /* CRBannerView.m in Sources */,
 				DF367CE023307AFB0044807B /* NSString+Criteo.m in Sources */,
 				547287892411096400B62235 /* CR_FeedbackStorage+MessageUpdating.m in Sources */,
-				198CDFA1D272C69DA0CE470D /* CASBoundedFileObjectQueue.m in Sources */,
+				198CDFA1D272C69DA0CE470D /* CR_CASBoundedFileObjectQueue.m in Sources */,
 				C07AB9ED69EB74DA88306686 /* CR_FeedbackFeatureGuard.m in Sources */,
 				469301CA24740289006F8D82 /* CR_ImpressionDetector.m in Sources */,
 				C07AB0B23BDBEA53346DD6CC /* CR_FeedbackController.m in Sources */,
@@ -1784,6 +1843,7 @@
 				C07ABC0F6A8997CD78597D6B /* CR_ImageCache.m in Sources */,
 				C07AB11AEFF7DFF4A4638A4F /* CR_RemoteConfigRequest.m in Sources */,
 				C07AB1021EE9DC0423DB6A20 /* CR_DisplaySizeInjector.m in Sources */,
+				4672E1DF251CDE02009F39EF /* CR_CASQueueFile.m in Sources */,
 				198CD81669DB4102F98AA7F2 /* CR_FeedbackConsentGuard.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1836,7 +1896,7 @@
 				462DCAA7246316B700B43A51 /* XCTestCase+Criteo.m in Sources */,
 				46AD5CF5245B003D00199315 /* CR_NativeLoaderTests.m in Sources */,
 				54C24BCD2404156A00DD9839 /* CR_FeedbackFileManagerTests.swift in Sources */,
-				467D34CA243E060A00852B4D /* CASBoundedFileObjectQueueTests.m in Sources */,
+				467D34CA243E060A00852B4D /* CR_CASBoundedFileObjectQueueTests.m in Sources */,
 				7D344F6B23D9A5F70029E653 /* CR_BidManagerIntegrationTests.m in Sources */,
 				7D3E424023915B6600BAF673 /* CRInterstitialAdUnitTests.m in Sources */,
 				7D00897023EAD19C00BA8F96 /* CRBannerViewDelegateMock.m in Sources */,

--- a/CriteoPublisherSdk/Sources/Cassette/.clang-format
+++ b/CriteoPublisherSdk/Sources/Cassette/.clang-format
@@ -1,0 +1,4 @@
+---
+DisableFormat: true
+SortIncludes: false
+---

--- a/CriteoPublisherSdk/Sources/Cassette/CR_CASError.h
+++ b/CriteoPublisherSdk/Sources/Cassette/CR_CASError.h
@@ -1,0 +1,29 @@
+//  Copyright 2016 LinkedIn Corporation
+//  Licensed under the BSD 2-Clause License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://opensource.org/licenses/BSD-2-Clause
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+FOUNDATION_EXPORT NSString *const CR_CASErrorDomain;
+FOUNDATION_EXPORT const int CR_CASErrorCode;
+
+typedef NS_ENUM(NSInteger, CR_CASErrorType) {
+    CR_CASErrorFileInitialization
+};
+
+@interface CR_CASError : NSObject
+
++ (NSError *)createError:(CR_CASErrorType)type;
++ (BOOL)handleError:(nullable NSError *)casError error:(NSError * __autoreleasing *)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/CriteoPublisherSdk/Sources/Cassette/CR_CASError.m
+++ b/CriteoPublisherSdk/Sources/Cassette/CR_CASError.m
@@ -1,0 +1,46 @@
+//  Copyright 2016 LinkedIn Corporation
+//  Licensed under the BSD 2-Clause License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://opensource.org/licenses/BSD-2-Clause
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and limitations under the License.
+
+#import "CR_CASError.h"
+
+NSString * const CR_CASErrorDomain = @"com.linkedin.LITape.ErrorDomain";
+const int CR_CASErrorCode = -7493;
+
+@implementation CR_CASError
+
++ (NSError *)createError:(CR_CASErrorType)type {
+    return [NSError errorWithDomain:CR_CASErrorDomain code:CR_CASErrorCode userInfo:[self userInfo:type]];
+}
+
++ (BOOL)handleError:(nullable NSError *)casError error:(NSError * __autoreleasing *)error {
+    if (casError) {
+        if (error) {
+            *error = casError;
+        }
+        return true;
+    }
+
+    return false;
+}
+
++ (NSDictionary *)userInfo:(CR_CASErrorType)type {
+    NSString *desc;
+    switch (type) {
+        case CR_CASErrorFileInitialization:
+            desc = @"Could not initialize file.";
+            break;
+        default:
+            desc = @"Unknown Cassette error. Developer likely mistakenly applied this as a Cassette error.";
+            break;
+    }
+    return @{ NSLocalizedDescriptionKey : desc };
+}
+
+@end

--- a/CriteoPublisherSdk/Sources/Cassette/CR_CASFileObjectQueue.h
+++ b/CriteoPublisherSdk/Sources/Cassette/CR_CASFileObjectQueue.h
@@ -1,0 +1,39 @@
+//  Copyright 2016 LinkedIn Corporation
+//  Licensed under the BSD 2-Clause License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://opensource.org/licenses/BSD-2-Clause
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and limitations under the License.
+
+#import "CR_CASObjectQueue.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * A queue of objects that is backed by a file. Objects must conform to
+ * protocol NSCoding to ensure proper serialization and deserialization.
+ */
+@interface CR_CASFileObjectQueue<T: id<NSCoding>> : CR_CASObjectQueue<T>
+
+/**
+ * Initializes an @c CR_CASFileObjectQueue with a file in the application's Library directory,
+ * returning nil if there was an error.
+ * Note: Intermediate directories will not be created, create containing directory before initializing.
+ */
+- (nullable instancetype)initWithRelativePath:(NSString *)filePath error:(NSError * __autoreleasing * _Nullable)error;
+
+/**
+ * Initializes an @c CR_CASFileObjectQueue with a file at the specified path,
+ * returning nil if there was an error.
+ * Note: Intermediate directories will not be created, create containing directory before initializing.
+ */
+- (nullable instancetype)initWithAbsolutePath:(NSString *)filePath error:(NSError * __autoreleasing * _Nullable)error;
+
+- (instancetype)init NS_UNAVAILABLE;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/CriteoPublisherSdk/Sources/Cassette/CR_CASFileObjectQueue.m
+++ b/CriteoPublisherSdk/Sources/Cassette/CR_CASFileObjectQueue.m
@@ -1,0 +1,113 @@
+//  Copyright 2016 LinkedIn Corporation
+//  Licensed under the BSD 2-Clause License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://opensource.org/licenses/BSD-2-Clause
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and limitations under the License.
+
+#import "CR_CASFileObjectQueue.h"
+#import "CR_CASPrivateConstants.h"
+#import "CR_CASQueueFile.h"
+
+@interface CR_CASFileObjectQueue ()
+
+/**
+ * Backing storage implementation
+ */
+@property (nonatomic, nonnull, strong, readonly) CR_CASQueueFile *queueFile;
+
+@property (nonatomic, assign) NSUInteger objectCount;
+
+@end
+
+@implementation CR_CASFileObjectQueue
+
+- (instancetype)initWithRelativePath:(NSString *)filePath error:(NSError * __autoreleasing * _Nullable)error {
+    NSArray<NSString *> *directoryPaths = NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES);
+    NSString *absolutePath = [directoryPaths[0] stringByAppendingPathComponent:filePath];
+    return [self initWithAbsolutePath:absolutePath error:error];
+}
+
+- (instancetype)initWithAbsolutePath:(NSString *)filePath error:(NSError * __autoreleasing * _Nullable)error {
+    if (self = [super init]) {
+        CR_CASQueueFile *queueFile = [CR_CASQueueFile queueFileWithPath:filePath error:error];
+        if (error != nil && *error != nil) {
+            return nil;
+        }
+        _queueFile = queueFile;
+    }
+    return self;
+}
+
+- (NSUInteger)size {
+    return self.queueFile.size;
+}
+
+- (void)add:(id)data {
+    NSError *error;
+    NSData *serializedData;
+    if (@available(iOS 11.0, macOS 10.13, *)) {
+        serializedData = [NSKeyedArchiver archivedDataWithRootObject:data
+                                               requiringSecureCoding:NO
+                                                               error:&error];
+    } else {
+        serializedData = [NSKeyedArchiver archivedDataWithRootObject:data];
+    }
+
+    if (error != nil) {
+        CR_CASLOG(@"error serializing data: %@", error.localizedDescription);
+    } else {
+        [self.queueFile add:serializedData];
+    }
+}
+
+- (NSArray<id> *)peek:(NSUInteger)amount {
+    NSArray<NSData *> *elements = [self.queueFile peek:amount];
+    NSMutableArray<id> *coercedElements = [[NSMutableArray alloc] init];
+    for (NSUInteger i = 0; i < elements.count; i++) {
+        NSData *element = elements[i];
+        id coercedElement = [self unarchiveData:element];
+        if (coercedElement != nil) {
+            [coercedElements addObject:coercedElement];
+        }
+    }
+    return coercedElements;
+}
+
+- (void)pop {
+    [self pop:1];
+}
+
+- (void)pop:(NSUInteger)amount {
+    [self.queueFile pop:amount];
+}
+
+- (void)clear {
+    [self.queueFile clear];
+}
+
+#pragma mark - Helper Method
+
+- (nullable id)unarchiveData:(NSData *)data {
+    id result;
+
+    if (@available(iOS 11.0, macOS 10.13, *)) {
+        NSError *error;
+        NSKeyedUnarchiver *unarchiver = [[NSKeyedUnarchiver alloc]
+                                         initForReadingFromData:data
+                                         error:&error];
+        [unarchiver setRequiresSecureCoding:NO];
+        result = [unarchiver decodeObjectForKey:NSKeyedArchiveRootObjectKey];
+        if (error != nil) {
+            CR_CASLOG(@"error unarchiving data: %@", error.localizedDescription);
+        }
+    } else {
+        result = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+    }
+    return result;
+}
+
+@end

--- a/CriteoPublisherSdk/Sources/Cassette/CR_CASInMemoryObjectQueue.h
+++ b/CriteoPublisherSdk/Sources/Cassette/CR_CASInMemoryObjectQueue.h
@@ -1,0 +1,15 @@
+//  Copyright 2016 LinkedIn Corporation
+//  Licensed under the BSD 2-Clause License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://opensource.org/licenses/BSD-2-Clause
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and limitations under the License.
+
+#import "CR_CASObjectQueue.h"
+
+@interface CR_CASInMemoryObjectQueue<T: id<NSCoding>> : CR_CASObjectQueue<T>
+
+@end

--- a/CriteoPublisherSdk/Sources/Cassette/CR_CASInMemoryObjectQueue.m
+++ b/CriteoPublisherSdk/Sources/Cassette/CR_CASInMemoryObjectQueue.m
@@ -1,0 +1,55 @@
+//  Copyright 2016 LinkedIn Corporation
+//  Licensed under the BSD 2-Clause License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://opensource.org/licenses/BSD-2-Clause
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and limitations under the License.
+
+#import "CR_CASInMemoryObjectQueue.h"
+
+@interface CR_CASInMemoryObjectQueue ()
+
+@property (nonatomic, strong, nonnull) NSMutableArray *inMemoryStorage;
+
+@end
+
+@implementation CR_CASInMemoryObjectQueue
+
+- (instancetype)init {
+    if (self = [super init]) {
+        _inMemoryStorage = [[NSMutableArray alloc] init];
+    }
+    return self;
+}
+
+- (void)add:(id)data {
+    [self.inMemoryStorage addObject:data];
+}
+
+- (NSUInteger)size {
+    return self.inMemoryStorage.count;
+}
+
+-(NSArray *)peek:(NSUInteger)amount {
+    // Clamp number of elements we read down to the size in case @c amount is larger
+    NSUInteger actualAmountToRetrieve = MIN(amount, self.size);
+    return [self.inMemoryStorage subarrayWithRange:NSMakeRange(0, actualAmountToRetrieve)];
+}
+
+- (void)pop:(NSUInteger)amount {
+    if (amount >= self.size) {
+        [self clear];
+        return;
+    }
+
+    [self.inMemoryStorage removeObjectsInRange:NSMakeRange(0, amount)];
+}
+
+- (void)clear {
+    [self.inMemoryStorage removeAllObjects];
+}
+
+@end

--- a/CriteoPublisherSdk/Sources/Cassette/CR_CASObjectQueue.h
+++ b/CriteoPublisherSdk/Sources/Cassette/CR_CASObjectQueue.h
@@ -1,0 +1,67 @@
+//  Copyright 2016 LinkedIn Corporation
+//  Licensed under the BSD 2-Clause License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://opensource.org/licenses/BSD-2-Clause
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * A queue of objects. This object should not be allocated directly.
+ * It serves as a base implementation for its child classes.
+ */
+@interface CR_CASObjectQueue<T: id<NSCoding>> : NSObject
+
+/**
+ * Adds an element to the end of the queue.
+ */
+- (void)add:(T)data;
+
+/**
+ * Returns the number of elements in this queue.
+ */
+- (NSUInteger)size;
+
+/**
+ * Returns true if this queue contains no entries.
+ */
+- (BOOL)isEmpty;
+
+/**
+ * Returns the head of the queue, or nil if the queue is empty. Does not modify the
+ * queue.
+ */
+- (nullable T)peek;
+
+/**
+ * Reads up to the specified amount of entries from the head of the queue without removing
+ * the entries.
+ * If the queue's @c size() is less than the amount specified, then only @c size() entries
+ * are read.
+ */
+- (NSArray<T> *)peek:(NSUInteger)amount;
+
+/**
+ * Removes the head of the queue.
+ */
+- (void)pop;
+
+/**
+ * Removes the specified amount of entries from the head of the queue.
+ */
+- (void)pop:(NSUInteger)amount;
+
+/**
+ * Clears this queue. Truncates the file to the initial size.
+ */
+- (void)clear;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/CriteoPublisherSdk/Sources/Cassette/CR_CASObjectQueue.m
+++ b/CriteoPublisherSdk/Sources/Cassette/CR_CASObjectQueue.m
@@ -1,0 +1,57 @@
+//  Copyright 2016 LinkedIn Corporation
+//  Licensed under the BSD 2-Clause License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://opensource.org/licenses/BSD-2-Clause
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and limitations under the License.
+
+#import "CR_CASObjectQueue.h"
+
+@implementation CR_CASObjectQueue
+
+- (void)add:(__unused id)data {
+    [NSException raise:NSInternalInconsistencyException
+                format:@"Must override LITapeObjectQueue method '%@' in subclass '%@'", NSStringFromSelector(_cmd), [self class]];
+}
+
+- (NSUInteger)size {
+    [NSException raise:NSInternalInconsistencyException
+                format:@"Must override LITapeObjectQueue method '%@' in subclass '%@'", NSStringFromSelector(_cmd), [self class]];
+    return 0;
+}
+
+- (BOOL)isEmpty {
+    return self.size == 0;
+}
+
+- (id)peek {
+    NSArray<id> *elements = [self peek:1];
+    if (elements.count > 0) {
+        return elements[0];
+    }
+    return nil;
+}
+
+- (NSArray<id> *)peek:(__unused NSUInteger)amount {
+    [NSException raise:NSInternalInconsistencyException
+                format:@"Must override LITapeObjectQueue method '%@' in subclass '%@'", NSStringFromSelector(_cmd), [self class]];
+    return @[];
+}
+
+- (void)pop {
+    [self pop:1];
+}
+
+- (void)pop:(__unused NSUInteger)amount {
+    [NSException raise:NSInternalInconsistencyException
+                format:@"Must override LITapeObjectQueue method '%@' in subclass '%@'", NSStringFromSelector(_cmd), [self class]];
+}
+
+- (void)clear {
+    [self pop:self.size];
+}
+
+@end

--- a/CriteoPublisherSdk/Sources/Cassette/CR_CASPrivateConstants.h
+++ b/CriteoPublisherSdk/Sources/Cassette/CR_CASPrivateConstants.h
@@ -1,0 +1,15 @@
+//  Copyright 2016 LinkedIn Corporation
+//  Licensed under the BSD 2-Clause License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://opensource.org/licenses/BSD-2-Clause
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and limitations under the License.
+
+#ifdef DEBUG
+#define CR_CASLOG(msg, ...) NSLog(msg, ##__VA_ARGS__)
+#else
+#define CR_CASLOG(msg, ...)
+#endif

--- a/CriteoPublisherSdk/Sources/Cassette/CR_CASQueueFile.h
+++ b/CriteoPublisherSdk/Sources/Cassette/CR_CASQueueFile.h
@@ -1,0 +1,72 @@
+//  Copyright 2016 LinkedIn Corporation
+//  Licensed under the BSD 2-Clause License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://opensource.org/licenses/BSD-2-Clause
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * A reliable, efficient, file-based, FIFO queue. Additions and removals are O(1). All operations
+ * are atomic. Writes are synchronous; data will be written to disk before an operation returns.
+ * The underlying file is structured to survive process and even system crashes. If an I/O
+ * exception is thrown during a mutating change, the change is aborted. It is safe to continue to
+ * use a @c CR_CASQueueFile instance after an exception.
+ *
+ * <p><strong>Note that this implementation is not synchronized.</strong>
+ */
+@interface CR_CASQueueFile : NSObject
+
+/**
+ * The primary way to construct an @c LITapeQueueFile.
+ */
++ (nullable CR_CASQueueFile *)queueFileWithPath:(NSString *)path error:(NSError * __autoreleasing * _Nullable)error;
+
+/**
+ * Initializing the queue file directly is unavailable.
+ * Please use the API @c queueFileWithPath
+ */
+- (instancetype)init NS_UNAVAILABLE;
+
+/**
+ * Adds an element to the end of the queue.
+ */
+- (void)add:(NSData *)data;
+
+/**
+ * Returns the number of elements in this queue.
+ */
+- (NSUInteger)size;
+
+/**
+ * Returns true if this queue contains no entries.
+ */
+- (BOOL)isEmpty;
+
+/**
+ * Reads up to the specified amount of entries from the head of the queue without removing
+ * the entries.
+ * If the queue's @c size() is less than the amount specified, then only @c size() entries
+ * are read.
+ */
+- (NSArray<NSData *> *)peek:(NSUInteger)amount;
+
+/**
+ * Removes the specified amount of entries from the head of the queue.
+ */
+- (void)pop:(NSUInteger)amount;
+
+/**
+ * Clears this queue. Truncates the file to the initial size.
+ */
+- (void)clear;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/CriteoPublisherSdk/Sources/Cassette/CR_CASQueueFile.m
+++ b/CriteoPublisherSdk/Sources/Cassette/CR_CASQueueFile.m
@@ -1,0 +1,523 @@
+//  Copyright 2016 LinkedIn Corporation
+//  Licensed under the BSD 2-Clause License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://opensource.org/licenses/BSD-2-Clause
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and limitations under the License.
+
+#import "CR_CASQueueFile.h"
+
+#import "CR_CASPrivateConstants.h"
+#import "CR_CASQueueFileElement.h"
+#import "CR_CASError.h"
+
+/**
+ * Initial file size in bytes.
+ */
+static NSUInteger const QueueFileInitialLength = 4096;
+
+/**
+ * Length of header in bytes.
+ */
+static NSUInteger const QueueFileHeaderLength = 16;
+
+/**
+ * Length of element header in bytes.
+ */
+static NSUInteger const ElementHeaderLength = 4;
+
+
+@interface CR_CASQueueFile ()
+
+@property (nonatomic, strong, readwrite) NSFileHandle *fileHandle;
+@property (nonatomic, strong, readwrite) NSString *commitFilePath;
+@property (nonatomic, strong, readwrite) NSFileManager *fileManager;
+
+/**
+ * In-memory buffer. This must be big enough to hold the header.
+ */
+@property (nonatomic, readwrite) NSMutableData *buffer;
+
+/**
+ * Cached file length. Always a power of 2.
+ */
+@property (nonatomic, readwrite) NSUInteger fileLength;
+
+/**
+ * The number of elements added.
+ */
+@property (nonatomic, readwrite) NSUInteger elementCount;
+
+/**
+ * Pointer to first element, at the front of the queue.
+ */
+@property (nonatomic, readwrite) CR_CASQueueFileElement *first;
+
+/**
+ * Pointer to last element, at the end of the queue.
+ */
+@property (nonatomic, readwrite) CR_CASQueueFileElement *last;
+
+@end
+
+// TODO several NSFileHandle API methods are deprecated in iOS 13. Will change once those APIs are stable.
+@implementation CR_CASQueueFile
+
+#pragma mark - Initialization
+
++ (nullable CR_CASQueueFile *)queueFileWithPath:(NSString *)path error:(NSError * __autoreleasing * _Nullable)error {
+    NSString *commitFilePath = commitFilePathForFile(path);
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    NSError *tapeError;
+
+    // There was an unfinished commit, clear and reinitialize.
+    if ([fileManager fileExistsAtPath:commitFilePath]) {
+        if (![fileManager removeItemAtPath:path error:&tapeError]) {
+            CR_CASLOG(@"Could not remove file at path: %@.", commitFilePath);
+            if ([CR_CASError handleError:tapeError error:error]) {
+                return nil;
+            }
+        }
+        if (![fileManager removeItemAtPath:commitFilePath error:&tapeError]) {
+            CR_CASLOG(@"Could not remove commit file at path: %@.", commitFilePath);
+            if ([CR_CASError handleError:tapeError error:error]) {
+                return nil;
+            }
+        }
+        [self safelySetUpFile:path forManager:fileManager error:&tapeError];
+    } else if (![fileManager fileExistsAtPath:path]) {
+        // There was no existing file, initialize one.
+        [self safelySetUpFile:path forManager:fileManager error:&tapeError];
+    }
+
+    if ([CR_CASError handleError:tapeError error:error]) {
+        return nil;
+    }
+
+    return [[self alloc] initWithPath:path forManager:fileManager];
+}
+
+/**
+ * Atomically initializes a new LITapeQueueFile at the given path.
+ */
++ (void)safelySetUpFile:(NSString *)path forManager:(NSFileManager *)fileManager error:(NSError * __autoreleasing * _Nullable)error {
+    NSError *tapeError;
+
+    // Use a temporary file so we don't leave a partially-initialized file.
+    NSString *tempPath = [path stringByAppendingPathExtension:@"tmp"];
+
+    // Write the initial set of data for the file
+    NSMutableData *fileBuffer = [NSMutableData dataWithLength:QueueFileInitialLength];
+    writeInt(fileBuffer, 0, QueueFileInitialLength);
+
+    BOOL isDirectory = YES;
+
+    NSString *folderPath = [path stringByDeletingLastPathComponent];
+
+    BOOL doesFolderExistAlready = [fileManager fileExistsAtPath:folderPath
+                                                    isDirectory:&isDirectory];
+
+    if (!doesFolderExistAlready) {
+        tapeError = [CR_CASError createError:CR_CASErrorFileInitialization];
+        CR_CASLOG(@"Creation of intermediary directories is not supported, please create folder path: %@", folderPath);
+        [CR_CASError handleError:tapeError error:error];
+        return;
+    }
+
+    if (!isDirectory) {
+        tapeError = [CR_CASError createError:CR_CASErrorFileInitialization];
+        CR_CASLOG(@"Could not create file because base directory is a file!: %@", folderPath);
+        [CR_CASError handleError:tapeError error:error];
+        return;
+    }
+
+    if (![fileManager createFileAtPath:tempPath
+                              contents:fileBuffer
+                            attributes:nil]) {
+        tapeError = [CR_CASError createError:CR_CASErrorFileInitialization];
+        CR_CASLOG(@"%@", [NSString stringWithFormat:@"Could not initialize file at path: %@.", tempPath]);
+        [CR_CASError handleError:tapeError error:error];
+        return;
+    }
+
+    if (![fileManager moveItemAtPath:tempPath
+                              toPath:path
+                               error:error]) {
+        CR_CASLOG(@"Could not move file from %@ to %@.", path, tempPath);
+        [CR_CASError handleError:tapeError error:error];
+        return;
+    }
+}
+
+- (instancetype)initWithPath:(NSString *)filePath
+                  forManager:(NSFileManager *)fileManager {
+    if (self = [super init]) {
+        _commitFilePath = commitFilePathForFile(filePath);
+        _fileManager = fileManager;
+        _fileHandle = [NSFileHandle fileHandleForUpdatingAtPath:filePath];
+        _buffer = [NSMutableData dataWithLength:QueueFileHeaderLength];
+
+        // Now that our main properties are set up, let's set up some fast access variables.
+        [self parseHeaderForFastAccessVariables];
+    }
+    return self;
+}
+
+/**
+ * Read the data stored in the header into instance variables.
+ */
+- (void)parseHeaderForFastAccessVariables {
+    [self.fileHandle seekToFileOffset:0];
+    NSData *buffer = [self.fileHandle readDataOfLength:QueueFileHeaderLength];
+
+    self.fileLength = readUnsignedInt(buffer, 0);
+    self.elementCount = readUnsignedInt(buffer, 4);
+    NSUInteger firstObjectOffset = readUnsignedInt(buffer, 8);
+    NSUInteger lastObjectOffset = readUnsignedInt(buffer, 12);
+
+    self.first = [self readElement:firstObjectOffset];
+    self.last = [self readElement:lastObjectOffset];
+}
+
+#pragma mark - Public API
+
+- (void)add:(NSData *)data {
+    [self expandIfNecessary:data.length];
+
+    // Insert a new element after the current last element.
+    BOOL wasEmpty = self.isEmpty;
+    NSUInteger position = wasEmpty ? QueueFileHeaderLength : [self wrapPosition:self.last.position + self.last.length + ElementHeaderLength];
+    CR_CASQueueFileElement *newLastElement = [[CR_CASQueueFileElement alloc] initAtPosition:position withLength:data.length];
+
+    // Write element length.
+    writeInt(self.buffer, 0, (uint32_t) data.length);
+    [self ringWriteAtPosition:newLastElement.position buffer:self.buffer];
+
+    // Write element's data.
+    [self ringWriteAtPosition:newLastElement.position + ElementHeaderLength buffer:data];
+
+    // Commit the addition. If wasEmpty, first == last.
+    NSUInteger firstPosition = wasEmpty ? newLastElement.position : self.first.position;
+    [self writeHeader:_fileLength
+         elementCount:_elementCount + 1
+        firstPosition:firstPosition
+         lastPosition:newLastElement.position];
+    self.last = newLastElement;
+    self.elementCount++;
+
+    // Handle edge case where this is the first element added
+    if (wasEmpty) {
+        self.first = self.last;
+    }
+}
+
+- (NSUInteger)size {
+    return self.elementCount;
+}
+
+- (BOOL)isEmpty {
+    return self.size == 0;
+}
+
+- (NSArray<NSData *> *)peek:(NSUInteger)amount {
+    // Clamp number of elements we read down to the size in case @c amount is larger
+    amount = MIN(amount, self.elementCount);
+    NSUInteger position = self.first.position;
+    NSMutableArray<NSData *> *elements = [[NSMutableArray alloc] init];
+
+    for (NSUInteger i = 0; i < amount; i++) {
+        // Read element from storage
+        CR_CASQueueFileElement *current = [self readElement:position];
+        NSData *data = [self ringReadAtPosition:current.position + ElementHeaderLength count:current.length];
+
+        // cache the result
+        [elements addObject:data];
+
+        // Move pointer to the next element
+        position = [self wrapPosition:current.position + ElementHeaderLength + current.length];
+    }
+
+    return elements;
+}
+
+- (void)pop:(NSUInteger)amount {
+    // Base case: Nothing to do if we have no elements
+    if (self.isEmpty || amount == 0) {
+        return;
+    }
+
+    // Optimize for clear call when possible since it is less expensive
+    if (amount >= self.elementCount) {
+        [self clear];
+        return;
+    }
+
+    NSUInteger eraseStartPosition = self.first.position;
+    NSUInteger totalLengthToErase = 0;
+
+    // Seek to the new "head", while recording how much data we need to erase.
+    NSUInteger newFirstPosition = self.first.position;
+    NSUInteger newFirstLength = self.first.length;
+    for (NSUInteger i = 0; i < amount; i++) {
+        totalLengthToErase += ElementHeaderLength + newFirstLength;
+        newFirstPosition = [self wrapPosition:newFirstPosition + ElementHeaderLength + newFirstLength];
+        NSData *buffer = [self ringReadAtPosition:newFirstPosition count:ElementHeaderLength];
+        newFirstLength = readUnsignedInt(buffer, 0);
+    }
+
+    // Commit the header and reassign pertinent in-memory variables
+    [self writeHeader:self.fileLength
+         elementCount:self.elementCount - amount
+        firstPosition:newFirstPosition
+         lastPosition:self.last.position];
+    self.elementCount -= amount;
+    self.first = [[CR_CASQueueFileElement alloc] initAtPosition:newFirstPosition withLength:newFirstLength];
+
+    // Zero out the data where the elements were removed
+    [self ringEraseAtPosition:eraseStartPosition length:totalLengthToErase];
+}
+
+- (void)clear {
+    // Reset the header
+    [self writeHeader:QueueFileInitialLength
+         elementCount:0
+        firstPosition:0
+         lastPosition:0];
+
+    // Zero out the data in our file storage
+    NSData *buffer = [NSMutableData dataWithLength:QueueFileInitialLength - QueueFileHeaderLength];
+    [self ringWriteAtPosition:QueueFileHeaderLength buffer:buffer];
+
+    // Reset in-memory variables
+    self.elementCount = 0;
+    self.first = CR_CASQueueFileElement.null;
+    self.last = CR_CASQueueFileElement.null;
+    if (self.fileLength > QueueFileInitialLength) {
+        [self setFile:self.fileHandle toLength:QueueFileInitialLength];
+    }
+    self.fileLength = QueueFileInitialLength;
+}
+
+#pragma mark - Private Helper Functions
+
+/**
+ * Reads the element stored at the given position in the file, wrapping around
+ * if necessary.
+ */
+- (CR_CASQueueFileElement *)readElement:(NSUInteger)position {
+    if (position == 0) {
+        return [CR_CASQueueFileElement null];
+    }
+    NSData *buffer = [self ringReadAtPosition:position count:ElementHeaderLength];
+    NSUInteger length = readUnsignedInt(buffer, 0);
+    return [[CR_CASQueueFileElement alloc] initAtPosition:(NSUInteger)position withLength:length];
+}
+
+/**
+ * Reads @c count bytes from the given position in the file, wrapping
+ * around if necessary.
+ */
+- (NSData *)ringReadAtPosition:(NSUInteger)position count:(NSUInteger)count {
+    position = [self wrapPosition:position];
+
+    // Handle the simple case where we don't wrap around
+    if (position + count < self.fileLength) {
+        [self.fileHandle seekToFileOffset:position];
+        return [self.fileHandle readDataOfLength:count];
+    }
+
+    // The requested read overlaps the EOF, so we need to read through to the EOF, wrap around, and read the remaining bytes
+    NSMutableData *buffer = [NSMutableData dataWithCapacity:count];
+    NSUInteger numBytesBeforeEOF = self.fileLength - position;
+    [self.fileHandle seekToFileOffset:position];
+    [buffer appendData:[self.fileHandle readDataOfLength:numBytesBeforeEOF]];
+    [self.fileHandle seekToFileOffset:QueueFileHeaderLength];
+    [buffer appendData:[self.fileHandle readDataOfLength:count - numBytesBeforeEOF]];
+    return buffer;
+}
+
+/**
+ * Writes buffer to position in file. Automatically wraps write if position is past the end of the file
+ * or if buffer overlaps it.
+ */
+- (void)ringWriteAtPosition:(NSUInteger)position buffer:(NSData *)buffer {
+    position = [self wrapPosition:position];
+
+    // Handle the simple case where we don't wrap around
+    if (position + buffer.length <= self.fileLength) {
+        [self.fileHandle seekToFileOffset:position];
+        [self.fileHandle writeData:buffer];
+    } else {
+        // The write overlaps the EOF.
+        // # of bytes to write before the EOF.
+        NSUInteger numBytesBeforeEOF = _fileLength - position;
+        [self.fileHandle seekToFileOffset:position];
+        [self.fileHandle writeData:[buffer subdataWithRange:NSMakeRange(0, numBytesBeforeEOF)]];
+        [self.fileHandle seekToFileOffset:QueueFileHeaderLength];
+        [self.fileHandle writeData:[buffer subdataWithRange:NSMakeRange(0 + numBytesBeforeEOF, buffer.length - numBytesBeforeEOF)]];
+    }
+
+    // Flush in-memory changes to permanent storage
+    [self.fileHandle synchronizeFile];
+}
+
+/**
+ * Zeroes out the file starting at @c position until @c length.
+ */
+- (void)ringEraseAtPosition:(NSUInteger)position length:(NSUInteger)length {
+    NSData *buffer = [NSMutableData dataWithLength:length];
+    [self ringWriteAtPosition:position buffer:buffer];
+}
+
+/**
+ * Writes header atomically. This only updates the state in the
+ * file. Assumes segment writes are atomic in the underlying file
+ * system.
+ */
+- (void)writeHeader:(NSUInteger)fileLength
+       elementCount:(NSUInteger)elementCount
+      firstPosition:(NSUInteger)firstPosition
+       lastPosition:(NSUInteger)lastPosition
+{
+    // Write header attributes to in-memory buffer
+    writeInt(self.buffer, 0, (uint32_t) fileLength);
+    writeInt(self.buffer, 4, (uint32_t) elementCount);
+    writeInt(self.buffer, 8, (uint32_t) firstPosition);
+    writeInt(self.buffer, 12, (uint32_t) lastPosition);
+
+    // Create temporary file to not lose the data
+    if (![self.fileManager createFileAtPath:self.commitFilePath
+                                   contents:self.buffer
+                                 attributes:nil]) {
+        CR_CASLOG(@"Could not initialize commit file at path: %@.", self.commitFilePath);
+    }
+
+    // Write header to file
+    [self.fileHandle seekToFileOffset:0];
+    [self.fileHandle writeData:self.buffer];
+    [self.fileHandle synchronizeFile];
+
+    // Remove the temporary file since it's no longer necessary
+    if (![self.fileManager removeItemAtPath:self.commitFilePath error:nil]) {
+        CR_CASLOG(@"Could not remove commit file at path: %@.", self.commitFilePath);
+    }
+}
+
+/**
+ * Wraps the position if it exceeds the end of the file.
+ */
+- (NSUInteger)wrapPosition:(NSUInteger)position {
+    return position < self.fileLength ? position : (QueueFileHeaderLength + position - self.fileLength);
+}
+
+/**
+ * If necessary, expands the file to accommodate an additional element of the
+ * given length.
+ */
+- (void)expandIfNecessary:(NSUInteger)elementLength {
+    NSUInteger numBytesRequested = ElementHeaderLength + elementLength;
+    NSUInteger remainingBytes = [self remainingBytes];
+
+    // The file has enough space to accomodate the new element. Return early
+    if (remainingBytes >= numBytesRequested) {
+        return;
+    }
+
+    // Resize the file to accomodate the new element.
+    NSUInteger previousFileLength = self.fileLength;
+    NSUInteger newFileLength;
+
+    // Double the length until we can fit the new data.
+    do {
+        newFileLength = previousFileLength << 1;
+        remainingBytes += previousFileLength;
+        previousFileLength = newFileLength;
+    } while (remainingBytes < numBytesRequested);
+
+    // Actually expand the file
+    [self setFile:self.fileHandle toLength:newFileLength];
+
+    // Calculate the position of the tail end of the data in the ring buffer
+    NSUInteger endOfLastElement = [self wrapPosition:self.last.position + ElementHeaderLength + self.last.length];
+
+    if (endOfLastElement <= self.first.position) {
+        // Hard luck. The data wrapped around to the head and is now fragmented due to file expansion.
+        // Copy the tail data after the head data to fix and make contiguous.
+        NSUInteger count = endOfLastElement - QueueFileHeaderLength;
+        NSData *buffer = [self ringReadAtPosition:QueueFileHeaderLength count:count];
+        [self.fileHandle seekToFileOffset:self.fileLength];
+        [self.fileHandle writeData:buffer];
+        [self ringEraseAtPosition:QueueFileHeaderLength length:count];
+    }
+
+    // Update the headers and in-memory variables
+    if (self.last.position < self.first.position) {
+        NSUInteger newLastPosition = self.fileLength + self.last.position - QueueFileHeaderLength;
+        [self writeHeader:newFileLength
+             elementCount:self.elementCount
+            firstPosition:self.first.position
+             lastPosition:newLastPosition];
+        self.last = [[CR_CASQueueFileElement alloc] initAtPosition:newLastPosition withLength:self.last.length];
+    } else {
+        [self writeHeader:newFileLength
+             elementCount:self.elementCount
+            firstPosition:self.first.position
+             lastPosition:self.last.position];
+    }
+    self.fileLength = newFileLength;
+}
+
+/**
+ * Truncates the specified file to the new length, and commits it to persisted storage.
+ */
+- (void)setFile:(NSFileHandle *)fileHandle toLength:(NSUInteger)newLength {
+    [fileHandle truncateFileAtOffset:newLength];
+    [fileHandle synchronizeFile];
+}
+
+- (NSUInteger)remainingBytes {
+    return self.fileLength - [self usedBytes];
+}
+
+- (NSUInteger)usedBytes {
+    if (self.elementCount == 0) {
+        return QueueFileHeaderLength;
+    }
+
+    if (self.last.position >= self.first.position) {
+        // Contiguous queue.
+        NSUInteger allButLastOccupiedSpace = self.last.position - self.first.position;
+        NSUInteger occupiedSpaceOfLastElement = ElementHeaderLength + self.last.length;
+        return allButLastOccupiedSpace + occupiedSpaceOfLastElement + QueueFileHeaderLength;
+    } else {
+        // The queue wraps.
+        NSUInteger headSpace = self.last.position + ElementHeaderLength + _last.length;
+        NSUInteger tailSpace = self.fileLength - self.first.position;
+        return headSpace + tailSpace;
+    }
+}
+
+/**
+ * Stores a 32-bit integer @c value in the @c buffer at the given @c offset.
+ */
+void writeInt(NSMutableData *buffer, NSUInteger offset, uint32_t value) {
+    [buffer replaceBytesInRange:NSMakeRange(offset, 4) withBytes:&value];
+}
+
+/**
+ * Reads a 32-bit integer value from the @c buffer at @c offset.
+ */
+NSUInteger readUnsignedInt(NSData *buffer, NSUInteger offset) {
+    uint32_t value;
+    [buffer getBytes:&value range:NSMakeRange(offset, 4)];
+    return value;
+}
+
+NSString *commitFilePathForFile(NSString *file) {
+    return [NSString stringWithFormat:@"%@.commit", file];
+}
+
+@end

--- a/CriteoPublisherSdk/Sources/Cassette/CR_CASQueueFileElement.h
+++ b/CriteoPublisherSdk/Sources/Cassette/CR_CASQueueFileElement.h
@@ -1,0 +1,40 @@
+//  Copyright 2016 LinkedIn Corporation
+//  Licensed under the BSD 2-Clause License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://opensource.org/licenses/BSD-2-Clause
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Object-based wrapper for dealing with elements in a @c CR_CASQueueFile.
+ */
+@interface CR_CASQueueFileElement : NSObject
+
+/**
+ * The position this element starts at in the @c CR_CASQueueFile.
+ */
+@property (nonatomic, assign) NSUInteger position;
+
+/**
+ * The amount of bytes this element occupies.
+ */
+@property (nonatomic, assign) NSUInteger length;
+
+/**
+ * Helper initializer to allocate an element such that it represents a nil element.
+ * Both position and length are initialized to zero.
+ */
++ (instancetype)null;
+- (instancetype)initAtPosition:(NSUInteger)position withLength:(NSUInteger)length NS_DESIGNATED_INITIALIZER;
+- (instancetype)init NS_UNAVAILABLE;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/CriteoPublisherSdk/Sources/Cassette/CR_CASQueueFileElement.m
+++ b/CriteoPublisherSdk/Sources/Cassette/CR_CASQueueFileElement.m
@@ -1,0 +1,27 @@
+//  Copyright 2016 LinkedIn Corporation
+//  Licensed under the BSD 2-Clause License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://opensource.org/licenses/BSD-2-Clause
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and limitations under the License.
+
+#import "CR_CASQueueFileElement.h"
+
+@implementation CR_CASQueueFileElement
+
++ (instancetype)null {
+    return [[CR_CASQueueFileElement alloc] initAtPosition:0 withLength:0];
+}
+
+- (instancetype)initAtPosition:(NSUInteger)position withLength:(NSUInteger)length {
+    if (self = [super init]) {
+        _position = position;
+        _length = length;
+    }
+    return self;
+}
+
+@end

--- a/CriteoPublisherSdk/Sources/Cassette/Cassette.h
+++ b/CriteoPublisherSdk/Sources/Cassette/Cassette.h
@@ -1,0 +1,13 @@
+//  Copyright 2016 LinkedIn Corporation
+//  Licensed under the BSD 2-Clause License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://opensource.org/licenses/BSD-2-Clause
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and limitations under the License.
+
+#import "CR_CASObjectQueue.h"
+#import "CR_CASFileObjectQueue.h"
+#import "CR_CASInMemoryObjectQueue.h"

--- a/CriteoPublisherSdk/Sources/Feedback/CR_CASBoundedFileObjectQueue.h
+++ b/CriteoPublisherSdk/Sources/Feedback/CR_CASBoundedFileObjectQueue.h
@@ -1,5 +1,5 @@
 //
-//  CASObjectQueue+ArraySet.h
+//  CR_CASBoundedFileObjectQueue.h
 //  CriteoPublisherSdk
 //
 //  Copyright © 2018-2020 Criteo. All rights reserved.
@@ -17,25 +17,22 @@
 // limitations under the License.
 //
 
-#import "CASObjectQueue.h"
-#import "CR_FeedbackMessage.h"
+#import "CR_CASFileObjectQueue.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface CASObjectQueue (ArraySet)
+@interface CR_CASBoundedFileObjectQueue<T : id <NSCoding>> : CR_CASFileObjectQueue <T>
 
 /**
- *  Adds an element to the end of the queue or assert if the object already exists.
+ * Initializes an @c CR_CASBoundedFileObjectQueue with a file at the specified path,
+ * with a file size boundary, returning nil if there was an error.
+ * Note: Intermediate directories will not be created, create containing
+ * directory before initializing.
  */
-- (void)addFeedbackMessage:(CR_FeedbackMessage *)data;
-/**
- * Return YES if the queue contains the given element.
- */
-- (BOOL)containsFeedbackMessage:(CR_FeedbackMessage *)data;
-/**
- * Return all the queued elements as an array.
- */
-- (NSArray *)allFeedbackMessages;
+- (nullable instancetype)initWithAbsolutePath:(NSString *)filePath
+                                maxFileLength:(NSUInteger)maxFileLength
+                                        error:(NSError *__autoreleasing *_Nullable)error
+    NS_DESIGNATED_INITIALIZER;
 
 @end
 

--- a/CriteoPublisherSdk/Sources/Feedback/CR_CASBoundedFileObjectQueue.m
+++ b/CriteoPublisherSdk/Sources/Feedback/CR_CASBoundedFileObjectQueue.m
@@ -1,5 +1,5 @@
 //
-//  CASBoundedFileObjectQueue.m
+//  CR_CASBoundedFileObjectQueue.m
 //  CriteoPublisherSdk
 //
 //  Copyright © 2018-2020 Criteo. All rights reserved.
@@ -17,26 +17,26 @@
 // limitations under the License.
 //
 
-#import "CASBoundedFileObjectQueue.h"
-#import "CASQueueFile.h"
+#import "CR_CASBoundedFileObjectQueue.h"
+#import "CR_CASQueueFile.h"
 
 /**
  * Expose the CASFileObjectQueue private queueFile.fileLength property
  * Starts with QueueFileInitialLength = 4096 then grows by *2 as needed
  */
-@interface CASFileObjectQueue (private)
-@property(nonatomic, nonnull, strong, readonly) CASQueueFile *queueFile;
+@interface CR_CASFileObjectQueue (private)
+@property(nonatomic, nonnull, strong, readonly) CR_CASQueueFile *queueFile;
 @end
 
-@interface CASQueueFile (private)
+@interface CR_CASQueueFile (private)
 @property(nonatomic, readwrite) NSUInteger fileLength;
 @end
 
-@interface CASBoundedFileObjectQueue ()
+@interface CR_CASBoundedFileObjectQueue ()
 @property(assign, nonatomic, readonly) NSUInteger maxFileLength;
 @end
 
-@implementation CASBoundedFileObjectQueue
+@implementation CR_CASBoundedFileObjectQueue
 
 - (instancetype)initWithAbsolutePath:(NSString *)filePath
                        maxFileLength:(NSUInteger)maxFileLength

--- a/CriteoPublisherSdk/Sources/Feedback/CR_CASObjectQueue+ArraySet.h
+++ b/CriteoPublisherSdk/Sources/Feedback/CR_CASObjectQueue+ArraySet.h
@@ -1,5 +1,5 @@
 //
-//  CASBoundedFileObjectQueue.h
+//  CR_CASObjectQueue+ArraySet.h
 //  CriteoPublisherSdk
 //
 //  Copyright © 2018-2020 Criteo. All rights reserved.
@@ -17,22 +17,25 @@
 // limitations under the License.
 //
 
-#import "CASFileObjectQueue.h"
+#import "CR_CASObjectQueue.h"
+#import "CR_FeedbackMessage.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface CASBoundedFileObjectQueue<T : id <NSCoding>> : CASFileObjectQueue <T>
+@interface CR_CASObjectQueue (ArraySet)
 
 /**
- * Initializes an @c CASBoundedFileObjectQueue with a file at the specified path,
- * with a file size boundary, returning nil if there was an error.
- * Note: Intermediate directories will not be created, create containing
- * directory before initializing.
+ *  Adds an element to the end of the queue or assert if the object already exists.
  */
-- (nullable instancetype)initWithAbsolutePath:(NSString *)filePath
-                                maxFileLength:(NSUInteger)maxFileLength
-                                        error:(NSError *__autoreleasing *_Nullable)error
-    NS_DESIGNATED_INITIALIZER;
+- (void)addFeedbackMessage:(CR_FeedbackMessage *)data;
+/**
+ * Return YES if the queue contains the given element.
+ */
+- (BOOL)containsFeedbackMessage:(CR_FeedbackMessage *)data;
+/**
+ * Return all the queued elements as an array.
+ */
+- (NSArray *)allFeedbackMessages;
 
 @end
 

--- a/CriteoPublisherSdk/Sources/Feedback/CR_CASObjectQueue+ArraySet.m
+++ b/CriteoPublisherSdk/Sources/Feedback/CR_CASObjectQueue+ArraySet.m
@@ -1,5 +1,5 @@
 //
-//  CASObjectQueue+ArraySet.m
+//  CR_CASObjectQueue+ArraySet.m
 //  CriteoPublisherSdk
 //
 //  Copyright © 2018-2020 Criteo. All rights reserved.
@@ -17,9 +17,9 @@
 // limitations under the License.
 //
 
-#import "CASObjectQueue+ArraySet.h"
+#import "CR_CASObjectQueue+ArraySet.h"
 
-@implementation CASObjectQueue (ArraySet)
+@implementation CR_CASObjectQueue (ArraySet)
 
 - (void)addFeedbackMessage:(CR_FeedbackMessage *)message {
   NSAssert(![self containsFeedbackMessage:message], @"Add to the queue an existing element: %@",

--- a/CriteoPublisherSdk/Sources/Feedback/CR_FeedbackStorage+Internal.h
+++ b/CriteoPublisherSdk/Sources/Feedback/CR_FeedbackStorage+Internal.h
@@ -27,7 +27,7 @@
 - (instancetype)initWithSendingQueueMaxSize:(NSUInteger)sendingQueueMaxSize
                                 fileManager:(id<CR_FeedbackFileManaging>)fileManager;
 
-- (CASObjectQueue<CR_FeedbackMessage *> *)
+- (CR_CASObjectQueue<CR_FeedbackMessage *> *)
     buildSendingQueueWithMaxSize:(NSUInteger)sendingQueueMaxSize
                      fileManager:(CR_FeedbackFileManager *)fileManage;
 

--- a/CriteoPublisherSdk/Sources/Feedback/CR_FeedbackStorage.h
+++ b/CriteoPublisherSdk/Sources/Feedback/CR_FeedbackStorage.h
@@ -18,7 +18,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <Cassette/Cassette.h>
+#import "Cassette.h"
 #import "CR_FeedbackFileManager.h"
 
 @class CR_FeedbackMessage;
@@ -29,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface CR_FeedbackStorage : NSObject
 
 - (instancetype)initWithFileManager:(id<CR_FeedbackFileManaging>)fileManaging
-                          withQueue:(CASObjectQueue<CR_FeedbackMessage *> *)queue
+                          withQueue:(CR_CASObjectQueue<CR_FeedbackMessage *> *)queue
     NS_DESIGNATED_INITIALIZER;
 
 - (instancetype)initWithSendingQueueMaxSize:(NSUInteger)sendingQueueMaxSize;

--- a/CriteoPublisherSdk/Sources/Feedback/CR_FeedbackStorage.m
+++ b/CriteoPublisherSdk/Sources/Feedback/CR_FeedbackStorage.m
@@ -20,13 +20,13 @@
 #import "CR_CacheAdUnit.h"
 #import "CR_FeedbackStorage.h"
 #import "CR_FeedbackFileManager.h"
-#import "CASObjectQueue+ArraySet.h"
-#import "CASBoundedFileObjectQueue.h"
+#import "CR_CASObjectQueue+ArraySet.h"
+#import "CR_CASBoundedFileObjectQueue.h"
 #import "Logging.h"
 
 @interface CR_FeedbackStorage ()
 
-@property(strong, nonatomic, readonly) CASObjectQueue<CR_FeedbackMessage *> *sendingQueue;
+@property(strong, nonatomic, readonly) CR_CASObjectQueue<CR_FeedbackMessage *> *sendingQueue;
 @property(strong, nonatomic, readonly) id<CR_FeedbackFileManaging> fileManaging;
 
 @end
@@ -49,7 +49,7 @@ static NSUInteger const CR_FeedbackStorageSendingQueueMaxSize = 256 * 1024;
 
 - (instancetype)initWithSendingQueueMaxSize:(NSUInteger)sendingQueueMaxSize
                                 fileManager:(id<CR_FeedbackFileManaging>)fileManager {
-  CASObjectQueue<CR_FeedbackMessage *> *queue = nil;
+  CR_CASObjectQueue<CR_FeedbackMessage *> *queue = nil;
   @try {
     queue = [self buildSendingQueueWithMaxSize:sendingQueueMaxSize fileManager:fileManager];
   } @catch (NSException *exception) {
@@ -61,16 +61,16 @@ static NSUInteger const CR_FeedbackStorageSendingQueueMaxSize = 256 * 1024;
   return [self initWithFileManager:fileManager withQueue:queue];
 }
 
-- (CASObjectQueue<CR_FeedbackMessage *> *)
+- (CR_CASObjectQueue<CR_FeedbackMessage *> *)
     buildSendingQueueWithMaxSize:(NSUInteger)sendingQueueMaxSize
                      fileManager:(CR_FeedbackFileManager *)fileManager {
-  return [[CASBoundedFileObjectQueue alloc] initWithAbsolutePath:fileManager.sendingQueueFilePath
-                                                   maxFileLength:sendingQueueMaxSize
-                                                           error:nil];
+  return [[CR_CASBoundedFileObjectQueue alloc] initWithAbsolutePath:fileManager.sendingQueueFilePath
+                                                      maxFileLength:sendingQueueMaxSize
+                                                              error:nil];
 }
 
 - (instancetype)initWithFileManager:(id<CR_FeedbackFileManaging>)fileManaging
-                          withQueue:(CASObjectQueue<CR_FeedbackMessage *> *)queue {
+                          withQueue:(CR_CASObjectQueue<CR_FeedbackMessage *> *)queue {
   if (self = [super init]) {
     _fileManaging = fileManaging;
     _sendingQueue = queue;

--- a/CriteoPublisherSdk/Tests/CriteoPublisherSdkTests-Bridging-Header.h
+++ b/CriteoPublisherSdk/Tests/CriteoPublisherSdkTests-Bridging-Header.h
@@ -2,7 +2,7 @@
 //  Use this file to import your target's public headers that you would like to
 //  expose to Swift.
 //
-#import <Cassette/Cassette.h>
+#import "Cassette.h"
 
 #import "CR_BidRequestSerializer.h"
 #import "CR_CacheAdUnit.h"

--- a/CriteoPublisherSdk/Tests/UnitTests/CR_BidManagerFeedbackSendingTests.m
+++ b/CriteoPublisherSdk/Tests/UnitTests/CR_BidManagerFeedbackSendingTests.m
@@ -27,7 +27,7 @@
 
 @property(nonatomic, strong) CR_BidManager *bidManager;
 @property(nonatomic, strong) CR_ApiHandler *apiHandlerMock;
-@property(nonatomic, strong) CASObjectQueue *feedbackSendingQueue;
+@property(nonatomic, strong) CR_CASObjectQueue *feedbackSendingQueue;
 @property(nonatomic, strong) CR_CacheAdUnit *adUnit;
 
 @end
@@ -37,7 +37,7 @@
 - (void)setUp {
   self.adUnit = [[CR_CacheAdUnit alloc] initWithAdUnitId:@"id" width:300 height:200];
   self.apiHandlerMock = OCMClassMock([CR_ApiHandler class]);
-  self.feedbackSendingQueue = [[CASInMemoryObjectQueue alloc] init];
+  self.feedbackSendingQueue = [[CR_CASInMemoryObjectQueue alloc] init];
   CR_FeedbackFileManagingMock *fileManagingMock = [[CR_FeedbackFileManagingMock alloc] init];
   CR_FeedbackStorage *feedbackStorage =
       [[CR_FeedbackStorage alloc] initWithFileManager:fileManagingMock

--- a/CriteoPublisherSdk/Tests/UnitTests/CR_BidManagerFeedbackTests.m
+++ b/CriteoPublisherSdk/Tests/UnitTests/CR_BidManagerFeedbackTests.m
@@ -47,7 +47,7 @@
 @property(nonatomic, strong) CR_CdbResponse *cdbResponseWithInvalidBid;
 
 @property(nonatomic, strong) CR_FeedbackFileManagingMock *feedbackFileManagingMock;
-@property(nonatomic, strong) CASObjectQueue *feedbackSendingQueue;
+@property(nonatomic, strong) CR_CASObjectQueue *feedbackSendingQueue;
 @property(nonatomic, strong) CR_BidManager *bidManager;
 @property(nonatomic, strong) CR_CacheManager *cacheManager;
 @property(nonatomic, strong) CR_ApiHandler *apiHandlerMock;
@@ -70,7 +70,7 @@
   self.cacheManager = [[CR_CacheManager alloc] init];
   self.feedbackFileManagingMock = [[CR_FeedbackFileManagingMock alloc] init];
   self.feedbackFileManagingMock.useReadWriteDictionary = YES;
-  self.feedbackSendingQueue = [[CASInMemoryObjectQueue alloc] init];
+  self.feedbackSendingQueue = [[CR_CASInMemoryObjectQueue alloc] init];
   CR_FeedbackStorage *feedbackStorage =
       [[CR_FeedbackStorage alloc] initWithFileManager:self.feedbackFileManagingMock
                                             withQueue:self.feedbackSendingQueue];

--- a/CriteoPublisherSdk/Tests/UnitTests/Feedback/CR_CASBoundedFileObjectQueueTests.m
+++ b/CriteoPublisherSdk/Tests/UnitTests/Feedback/CR_CASBoundedFileObjectQueueTests.m
@@ -1,5 +1,5 @@
 //
-//  CASBoundedFileObjectQueueTests.m
+//  CR_CASBoundedFileObjectQueueTests.m
 //  CriteoPublisherSdkTests
 //
 //  Copyright © 2018-2020 Criteo. All rights reserved.
@@ -18,15 +18,15 @@
 //
 
 #import <XCTest/XCTest.h>
-#import "CASBoundedFileObjectQueue.h"
+#import "CR_CASBoundedFileObjectQueue.h"
 
-@interface CASBoundedFileObjectQueueTests : XCTestCase
-@property(strong, nonatomic) CASBoundedFileObjectQueue *queue;
+@interface CR_CASBoundedFileObjectQueueTests : XCTestCase
+@property(strong, nonatomic) CR_CASBoundedFileObjectQueue *queue;
 @end
 
-static const NSUInteger CASBoundedFileObjectQueueTestsMaxFileLength = 1024 * 8;
+static const NSUInteger CR_CASBoundedFileObjectQueueTestsMaxFileLength = 1024 * 8;
 
-@implementation CASBoundedFileObjectQueueTests
+@implementation CR_CASBoundedFileObjectQueueTests
 
 + (NSString *)testQueuePath {
   NSString *tempPath = NSTemporaryDirectory();
@@ -45,9 +45,9 @@ static const NSUInteger CASBoundedFileObjectQueueTestsMaxFileLength = 1024 * 8;
 - (void)setUp {
   [super setUp];
   NSError *error = nil;
-  self.queue = [[CASBoundedFileObjectQueue alloc]
+  self.queue = [[CR_CASBoundedFileObjectQueue alloc]
       initWithAbsolutePath:self.class.testQueuePath
-             maxFileLength:CASBoundedFileObjectQueueTestsMaxFileLength
+             maxFileLength:CR_CASBoundedFileObjectQueueTestsMaxFileLength
                      error:&error];
   XCTAssertNil(error);
 }
@@ -61,7 +61,7 @@ static const NSUInteger CASBoundedFileObjectQueueTestsMaxFileLength = 1024 * 8;
   XCTAssertNotNil(self.queue);
 }
 
-- (void)addDummyObjectsToQueue:(CASObjectQueue *)queue size:(NSUInteger)size {
+- (void)addDummyObjectsToQueue:(CR_CASObjectQueue *)queue size:(NSUInteger)size {
   static const NSUInteger dummyObjectSize = 1024;
   void *dummyBytes = malloc(dummyObjectSize);
   NSData *dummyObject = [NSData dataWithBytes:dummyBytes length:dummyObjectSize];
@@ -73,16 +73,16 @@ static const NSUInteger CASBoundedFileObjectQueueTestsMaxFileLength = 1024 * 8;
 - (void)testReachBoundOut {
   NSUInteger initialQueueSize = self.queue.size;
   // Fill queue
-  [self addDummyObjectsToQueue:self.queue size:CASBoundedFileObjectQueueTestsMaxFileLength];
+  [self addDummyObjectsToQueue:self.queue size:CR_CASBoundedFileObjectQueueTestsMaxFileLength];
   XCTAssertLessThan(initialQueueSize, self.queue.size, @"Queue should have grown");
 }
 
 - (void)testInsertOutOfBound {
   // Fill queue
-  [self addDummyObjectsToQueue:self.queue size:CASBoundedFileObjectQueueTestsMaxFileLength];
+  [self addDummyObjectsToQueue:self.queue size:CR_CASBoundedFileObjectQueueTestsMaxFileLength];
   NSUInteger boundedQueueSize = self.queue.size;
   // Add data out of bound
-  [self addDummyObjectsToQueue:self.queue size:CASBoundedFileObjectQueueTestsMaxFileLength];
+  [self addDummyObjectsToQueue:self.queue size:CR_CASBoundedFileObjectQueueTestsMaxFileLength];
   XCTAssertEqual(boundedQueueSize, self.queue.size, @"Queue should not grow anymore");
 }
 

--- a/CriteoPublisherSdk/Tests/UnitTests/Feedback/CR_FeedbackControllerTests.m
+++ b/CriteoPublisherSdk/Tests/UnitTests/Feedback/CR_FeedbackControllerTests.m
@@ -29,7 +29,7 @@
 @interface CR_FeedbackControllerTests : XCTestCase
 
 @property(nonatomic, strong) CR_FeedbackFileManagingMock *feedbackFileManagingMock;
-@property(nonatomic, strong) CASObjectQueue *feedbackSendingQueue;
+@property(nonatomic, strong) CR_CASObjectQueue *feedbackSendingQueue;
 @property(nonatomic, strong) CR_FeedbackStorage *feedbackStorage;
 @property(nonatomic, strong) CR_ApiHandler *apiHandler;
 @property(nonatomic, strong) CR_Config *config;
@@ -55,7 +55,7 @@
 
   self.feedbackFileManagingMock = [[CR_FeedbackFileManagingMock alloc] init];
   self.feedbackFileManagingMock.useReadWriteDictionary = YES;
-  self.feedbackSendingQueue = [[CASInMemoryObjectQueue alloc] init];
+  self.feedbackSendingQueue = [[CR_CASInMemoryObjectQueue alloc] init];
   self.feedbackStorage =
       [[CR_FeedbackStorage alloc] initWithFileManager:self.feedbackFileManagingMock
                                             withQueue:self.feedbackSendingQueue];

--- a/CriteoPublisherSdk/Tests/UnitTests/Feedback/CR_FeedbackStorageTests.swift
+++ b/CriteoPublisherSdk/Tests/UnitTests/Feedback/CR_FeedbackStorageTests.swift
@@ -23,7 +23,7 @@ import XCTest
 class CR_FeedbackStorageTests: XCTestCase {
 
   var fileManagingMock: CR_FeedbackFileManagingMock = CR_FeedbackFileManagingMock()
-  var queue: CASObjectQueue<CR_FeedbackMessage> = CASInMemoryObjectQueue<CR_FeedbackMessage>()
+  var queue: CR_CASObjectQueue<CR_FeedbackMessage> = CR_CASInMemoryObjectQueue<CR_FeedbackMessage>()
   var feedbackStorage: CR_FeedbackStorage = CR_FeedbackStorage()
   var impressionId1: String = "impressionId"
   var impressionId2: String = "impressionId2"
@@ -33,7 +33,7 @@ class CR_FeedbackStorageTests: XCTestCase {
   override func setUp() {
     super.setUp()
     fileManagingMock = CR_FeedbackFileManagingMock()
-    queue = CASInMemoryObjectQueue<CR_FeedbackMessage>()
+    queue = CR_CASInMemoryObjectQueue<CR_FeedbackMessage>()
     feedbackStorage = CR_FeedbackStorage(fileManager: fileManagingMock, with: queue)
   }
 
@@ -250,7 +250,7 @@ class CR_FeedbackCorruptedStorage: CR_FeedbackStorage {
   var crashedOnce = false
 
   @objc override func buildSendingQueue(withMaxSize: UInt, fileManager: CR_FeedbackFileManager!)
-    -> CASObjectQueue<CR_FeedbackMessage>
+    -> CR_CASObjectQueue<CR_FeedbackMessage>
   {
     if !crashedOnce {
       crashedOnce = true

--- a/CriteoPublisherSdk/Tests/Utility/Categories/CR_DependencyProvider+Testing.m
+++ b/CriteoPublisherSdk/Tests/Utility/Categories/CR_DependencyProvider+Testing.m
@@ -72,7 +72,7 @@
   CR_FeedbackFileManagingMock *feedbackFileManagingMock =
       [[CR_FeedbackFileManagingMock alloc] init];
   feedbackFileManagingMock.useReadWriteDictionary = YES;
-  CASInMemoryObjectQueue *feedbackSendingQueue = [[CASInMemoryObjectQueue alloc] init];
+  CR_CASInMemoryObjectQueue *feedbackSendingQueue = [[CR_CASInMemoryObjectQueue alloc] init];
   CR_FeedbackStorage *feedbackStorage =
       [[CR_FeedbackStorage alloc] initWithFileManager:feedbackFileManagingMock
                                             withQueue:feedbackSendingQueue];

--- a/Podfile
+++ b/Podfile
@@ -4,7 +4,6 @@ workspace 'CriteoPublisherSdk'
 
 target 'CriteoPublisherSdk' do
   project 'CriteoPublisherSdk/CriteoPublisherSdk'
-  pod 'Cassette', '~> 1.0-beta'
 end
 
 target 'CriteoPublisherSdkTests' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,4 @@
 PODS:
-  - Cassette (1.0.0-beta3)
   - Eureka (5.3.0)
   - FunctionalObjC (1.0.2)
   - Google-Mobile-Ads-SDK (7.65.0):
@@ -40,7 +39,6 @@ PODS:
   - SwiftLint (0.40.3)
 
 DEPENDENCIES:
-  - Cassette (~> 1.0-beta)
   - Eureka
   - FunctionalObjC (~> 1.0)
   - Google-Mobile-Ads-SDK
@@ -51,7 +49,6 @@ DEPENDENCIES:
 
 SPEC REPOS:
   trunk:
-    - Cassette
     - Eureka
     - FunctionalObjC
     - Google-Mobile-Ads-SDK
@@ -65,7 +62,6 @@ SPEC REPOS:
     - SwiftLint
 
 SPEC CHECKSUMS:
-  Cassette: bd5900e0b8d67c796ca82272ff5ee388320cfc61
   Eureka: 49239596c9d2eed9ab523990c34de62b6feac9f0
   FunctionalObjC: bd6aaa4b69abea0a5ac0e860a052c1ebebd5311c
   Google-Mobile-Ads-SDK: af735e001ee534d9dd2ce0a87cd8c355b19844b5
@@ -78,6 +74,6 @@ SPEC CHECKSUMS:
   PromisesObjC: b14b1c6b68e306650688599de8a45e49fae81151
   SwiftLint: dfd554ff0dff17288ee574814ccdd5cea85d76f7
 
-PODFILE CHECKSUM: f5333aeb67a6187587c049b9debfac6103d60368
+PODFILE CHECKSUM: b21ea8b34a8cb042bab33c0789403dd9edc29852
 
 COCOAPODS: 1.9.3

--- a/SupportFiles/SupportFiles.xcodeproj/project.pbxproj
+++ b/SupportFiles/SupportFiles.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXFileReference section */
+		198CDAFB73A16BE6C19EE005 /* import-cassette.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; name = "import-cassette.sh"; path = "../scripts/import-cassette.sh"; sourceTree = "<group>"; };
 		466AEEED24C6EB2F0034081E /* Gemfile */ = {isa = PBXFileReference; lastKnownFileType = text; name = Gemfile; path = ../Gemfile; sourceTree = "<group>"; };
 		466AEEEE24C6EB2F0034081E /* CriteoPublisherSdk.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; name = CriteoPublisherSdk.podspec; path = ../CriteoPublisherSdk.podspec; sourceTree = "<group>"; };
 		466AEEEF24C6EB2F0034081E /* tools */ = {isa = PBXFileReference; lastKnownFileType = folder; name = tools; path = ../tools; sourceTree = "<group>"; };
@@ -37,6 +38,7 @@
 				466AEEF424C6EB300034081E /* scripts */,
 				466AEEEF24C6EB2F0034081E /* tools */,
 				466AEEF124C6EB300034081E /* wiremock */,
+				198CDAFB73A16BE6C19EE005 /* import-cassette.sh */,
 			);
 			sourceTree = "<group>";
 		};

--- a/scripts/import-cassette.sh
+++ b/scripts/import-cassette.sh
@@ -1,0 +1,34 @@
+#!/bin/bash -l
+
+CASSETTE_FOLDER=CriteoPublisherSdk/Sources/Cassette
+
+# Cleanup
+rm -rf $CASSETTE_FOLDER
+
+# Shallow clone
+git clone -b master --single-branch --depth 1 \
+    git@github.com:linkedin/cassette.git \
+    $CASSETTE_FOLDER.tmp
+
+# Only keep library source
+mv $CASSETTE_FOLDER.tmp/Cassette $CASSETTE_FOLDER
+rm -rf $CASSETTE_FOLDER.tmp $CASSETTE_FOLDER/Info.plist
+
+# Prefix file names
+for file in $CASSETTE_FOLDER/CAS*.{h,m}; do
+  mv "$file" "${file/CAS/CR_CAS}"
+done
+
+# Prefix class names
+sed -i '' "s/CAS/CR_CAS/g" $CASSETTE_FOLDER/*.{h,m}
+
+# Fix imports
+sed -i '' "s/#import <Cassette\/\(.*\)>/#import \"\1\"/g" $CASSETTE_FOLDER/*.{h,m}
+
+# Exclude it from clang-format
+cat <<EOF >> $CASSETTE_FOLDER/.clang-format
+---
+DisableFormat: true
+SortIncludes: false
+---
+EOF

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -15,4 +15,7 @@ crto-echo "[Bundle] Updating Gems..."
 bundle update
 crto-echo "[CocoaPods] Updating Pods..."
 bundle exec pod update
+crto-echo "[Includes] Updating included libs..."
+"$SCRIPT_DIRECTORY"/import-cassette.sh
+
 crto-echo "Update complete."


### PR DESCRIPTION
As it prevents eventual name clashing if someone wanted to use Sdk + Cassette, and also is a blocker to Swift Package Manager support (#94)