### PR TITLE
Add a link to sample project repository in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@
 Please refer to the [App Developer Portal](https://publisherdocs.criteotilt.com/app/ios/), for
 detailed setup and usage instructions.
 
+## Integration Examples
+Please refer to the [iOS Sample App](https://github.com/criteo/ios-publisher-sdk-examples) repository.
+
 ## Questions & Support
 Please contact your technical support representative for any questions about the SDK.
 


### PR DESCRIPTION
Some publishers have mistaken the test app in this repository as the sample app for integrations. Adding a link to the sample repository in Readme would be useful to lead them to the right sample.