### PR TITLE
Fix tests not being run by CI

### DIFF
--- a/CriteoPublisherSdk/Tests/Utility/Categories/Criteo+Testing.m
+++ b/CriteoPublisherSdk/Tests/Utility/Categories/Criteo+Testing.m
@@ -111,13 +111,8 @@ NSString *const PreprodNativeAdUnitId = @"test-PubSdk-Native";
   CR_NetworkWaiterBuilder *builder =
       [[CR_NetworkWaiterBuilder alloc] initWithConfig:self.config
                                         networkCaptor:self.testing_networkCaptor];
-  CR_NetworkWaiterBuilder *waiterBuilder =
-      builder.withConfig.withLaunchAppEvent.withFinishedRequestsIncluded;
-  if (!self.config.liveBiddingEnabled) {
-    // Bid prefetch is expected
-    waiterBuilder = waiterBuilder.withBid;
-  }
-  CR_NetworkWaiter *waiter = waiterBuilder.build;
+  CR_NetworkWaiter *waiter =
+      builder.withBid.withConfig.withLaunchAppEvent.withFinishedRequestsIncluded.build;
   return [waiter wait];
 }
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -24,7 +24,9 @@ platform :ios do
     scan(scheme: "CriteoGoogleAdapter")
     scan(scheme: "CriteoMoPubAdapter")
     multi_scan(
+      workspace: "CriteoPublisherSdk.xcworkspace",
       scheme: "CriteoPublisherSdk",
+      testplan: "CriteoPublisherSdk",
       try_count: 5, parallel_testrun_count: 2,
     )
   end


### PR DESCRIPTION
multi_scan does not pick the scheme default testplan as Xcode does.
As a consequence CI was running the Standalone plan introduced
recently, only 78 of 722 tests... ¯\\\_(ツ)_/¯