### PR TITLE
[Tests] Fix wiremock endpoint urls

### DIFF
--- a/CriteoPublisherSdk/Tests/Utility/Categories/CR_DependencyProvider+Testing.m
+++ b/CriteoPublisherSdk/Tests/Utility/Categories/CR_DependencyProvider+Testing.m
@@ -44,8 +44,8 @@
 }
 
 - (NSString *)wireMockEndPoint:(NSString *)path {
-  static const NSString *wireMockUrl = @"https://localhost:9099";
-  return [wireMockUrl stringByAppendingPathComponent:path];
+  static const NSString *wireMockUrl = @"https://localhost:9099/";
+  return [wireMockUrl stringByAppendingString:path];
 }
 
 - (CR_DependencyProvider *)withWireMockConfiguration {


### PR DESCRIPTION
Should not affect tests, but endpoints built this way were wrong.
stringByAppendingPath transforming https:// into https:/.