### PR TITLE
Use gdpr_consent instead of gdprString for GUM

### DIFF
--- a/CriteoPublisherSdk/Sources/Network/CR_ApiHandler.m
+++ b/CriteoPublisherSdk/Sources/Network/CR_ApiHandler.m
@@ -261,7 +261,7 @@ static NSUInteger const maxAdUnitsPerCdbRequest = 8;
   paramDict[CR_ApiQueryKeys.eventType] = event;
   paramDict[CR_ApiQueryKeys.appId] = config.appId;
   paramDict[CR_ApiQueryKeys.limitedAdTracking] = consent.isAdTrackingEnabled ? @"0" : @"1";
-  paramDict[CR_ApiQueryKeys.gdprString] = consent.gdpr.consentString;
+  paramDict[CR_ApiQueryKeys.gdprConsentForGum] = consent.gdpr.consentString;
   NSString *params = [NSString cr_urlQueryParamsWithDictionary:paramDict];
   return params;
 }

--- a/CriteoPublisherSdk/Sources/Network/CR_ApiQueryKeys.h
+++ b/CriteoPublisherSdk/Sources/Network/CR_ApiQueryKeys.h
@@ -51,7 +51,7 @@
 /** @property gdprString
  *  @brief gdprString property is used for the app event request (gum)
  */
-@property(class, nonatomic, readonly) NSString *gdprString;
+@property(class, nonatomic, readonly) NSString *gdprConsentForGum;
 
 @property(class, nonatomic, readonly) NSString *gdprApplies;
 @property(class, nonatomic, readonly) NSString *gdprConsentData;

--- a/CriteoPublisherSdk/Sources/Network/CR_ApiQueryKeys.m
+++ b/CriteoPublisherSdk/Sources/Network/CR_ApiQueryKeys.m
@@ -87,8 +87,8 @@
 + (NSString *)gdprConsent {
   return @"gdprConsent";
 }
-+ (NSString *)gdprString {
-  return @"gdprString";
++ (NSString *)gdprConsentForGum {
+  return @"gdpr_consent";
 }
 + (NSString *)gdprApplies {
   return @"gdprApplies";

--- a/CriteoPublisherSdk/Tests/IntegrationTests/CR_DataConsentFunctionalTests.m
+++ b/CriteoPublisherSdk/Tests/IntegrationTests/CR_DataConsentFunctionalTests.m
@@ -84,7 +84,8 @@
   [self.criteo testing_registerBannerAndWaitForHTTPResponses];
 
   XCTAssertEqualObjects(self.gdprInBidRequest, expected);
-  XCTAssertNotNil(self.appEventUrlString.cr_urlQueryParamsDictionary[NSString.gdprStringKey]);
+  XCTAssertNotNil(
+      self.appEventUrlString.cr_urlQueryParamsDictionary[NSString.gdprConsentKeyForGum]);
 }
 
 - (void)testGivenGdprV1Set_whenCriteoRegister_thenConsentStringSetInBidRequest {
@@ -99,7 +100,8 @@
   [self.criteo testing_registerBannerAndWaitForHTTPResponses];
 
   XCTAssertEqualObjects(self.gdprInBidRequest, expected);
-  XCTAssertNotNil(self.appEventUrlString.cr_urlQueryParamsDictionary[NSString.gdprStringKey]);
+  XCTAssertNotNil(
+      self.appEventUrlString.cr_urlQueryParamsDictionary[NSString.gdprConsentKeyForGum]);
 }
 
 - (void)testGivenGdprV2Set_whenCriteoRegister_thenConsentStringSetInBidRequest {

--- a/CriteoPublisherSdk/Tests/UnitTests/Network/CR_ApiHandlerTests.m
+++ b/CriteoPublisherSdk/Tests/UnitTests/Network/CR_ApiHandlerTests.m
@@ -641,7 +641,7 @@
   [self callSendAppEventWithCompletionHandler:nil];
 
   NSString *gdprEncodedString =
-      self.appEventUrlString.cr_urlQueryParamsDictionary[NSString.gdprStringKey];
+      self.appEventUrlString.cr_urlQueryParamsDictionary[NSString.gdprConsentKeyForGum];
   XCTAssertEqualObjects(gdprEncodedString, @"ssds");
 }
 

--- a/CriteoPublisherSdk/Tests/Utility/Categories/NSString+APIKeys.h
+++ b/CriteoPublisherSdk/Tests/Utility/Categories/NSString+APIKeys.h
@@ -47,7 +47,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark GDPR
 
 @property(copy, nonatomic, class, readonly) NSString *gdprConsentKey;
-@property(copy, nonatomic, class, readonly) NSString *gdprStringKey;
+@property(copy, nonatomic, class, readonly) NSString *gdprConsentKeyForGum;
 @property(copy, nonatomic, class, readonly) NSString *gdprVersionKey;
 @property(copy, nonatomic, class, readonly) NSString *gdprConsentDataKey;
 @property(copy, nonatomic, class, readonly) NSString *gdprAppliesKey;

--- a/CriteoPublisherSdk/Tests/Utility/Categories/NSString+APIKeys.m
+++ b/CriteoPublisherSdk/Tests/Utility/Categories/NSString+APIKeys.m
@@ -81,8 +81,8 @@
   return @"gdprConsent";
 }
 
-+ (NSString *)gdprStringKey {
-  return @"gdprString";
++ (NSString *)gdprConsentKeyForGum {
+  return @"gdpr_consent";
 }
 
 + (NSString *)gdprAppliesKey {


### PR DESCRIPTION
Although this is not consistent with all the other keys,
PTag already uses this key and the idea was to align with
IAB standard.