### PR TITLE
Add placeholder interface for storing remote log records

### DIFF
--- a/CriteoPublisherSdk/CriteoPublisherSdk.xcodeproj/project.pbxproj
+++ b/CriteoPublisherSdk/CriteoPublisherSdk.xcodeproj/project.pbxproj
@@ -289,8 +289,10 @@
 		C07AB53ECEC45D1A7D9EA259 /* CRMediaViewTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C07ABD1BF4C0321B88411398 /* CRMediaViewTests.m */; };
 		C07AB5492FE17D797F4C1306 /* CRMediaView.m in Sources */ = {isa = PBXBuildFile; fileRef = C07AB093A865F67283614A5D /* CRMediaView.m */; };
 		C07AB6C51EDDDE87A80D2666 /* CRMediaContent.h in Headers */ = {isa = PBXBuildFile; fileRef = C07ABFCB3CD0F740F0A7FB05 /* CRMediaContent.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C07AB6D02AA13693FEFF215F /* CR_RemoteLogRecordTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C07AB0F74CBE74DC33F6ED1C /* CR_RemoteLogRecordTests.m */; };
 		C07AB6FAFCA3CA34578C1C5A /* CR_InternalContextProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = C07AB8E611CB1C503E117386 /* CR_InternalContextProvider.m */; };
 		C07AB779584EBF6DBACED48F /* NSUserDefaults+CR_Config.m in Sources */ = {isa = PBXBuildFile; fileRef = C07AB1709D918AD4DA7A4384 /* NSUserDefaults+CR_Config.m */; };
+		C07AB80BC9B93DC2ADC387F0 /* CR_RemoteLogStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = C07ABBECE75DACD69AC68FCE /* CR_RemoteLogStorage.h */; };
 		C07AB825779A15495508A590 /* CR_UserDataHolder.h in Headers */ = {isa = PBXBuildFile; fileRef = C07ABA1B386190CDE12F3853 /* CR_UserDataHolder.h */; };
 		C07AB87AEEBF8383E4C029F6 /* CR_FeedbackFeatureGuardTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C07ABEC0FA1873D8B0882250 /* CR_FeedbackFeatureGuardTests.m */; };
 		C07AB8CAC5AA0D8D9A3B9764 /* CRContextData+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = C07ABE9C517574E8D3DBE4EC /* CRContextData+Internal.h */; };
@@ -298,6 +300,7 @@
 		C07AB936F1DBBE6CC8C2644E /* CRMediaContent.m in Sources */ = {isa = PBXBuildFile; fileRef = C07ABD4814092221709B77BA /* CRMediaContent.m */; };
 		C07AB96240CAD13D1FC39753 /* CR_ImageCache.h in Headers */ = {isa = PBXBuildFile; fileRef = C07ABDA25C65E3BBAAF68A79 /* CR_ImageCache.h */; };
 		C07AB98B6BF9878FBBD190FF /* CriteoTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C07ABBFC2256322A8A934EF7 /* CriteoTests.m */; };
+		C07AB9BD9115E79936C90A99 /* CR_RemoteLogRecord.h in Headers */ = {isa = PBXBuildFile; fileRef = C07AB97FE6D2C0F49B55316F /* CR_RemoteLogRecord.h */; };
 		C07AB9ED69EB74DA88306686 /* CR_FeedbackFeatureGuard.m in Sources */ = {isa = PBXBuildFile; fileRef = C07AB7277BC095D4A7DF86E2 /* CR_FeedbackFeatureGuard.m */; };
 		C07AB9F79CF1495A3E493B8B /* CRUserData.m in Sources */ = {isa = PBXBuildFile; fileRef = C07AB9F9A3CAB239567053D2 /* CRUserData.m */; };
 		C07AB9F7F2A6BB33242A47D5 /* CR_DisplaySizeInjectorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C07AB4BAE67CF9EC778F3E5C /* CR_DisplaySizeInjectorTests.m */; };
@@ -308,6 +311,7 @@
 		C07ABAA1393B946F538A802C /* CR_ImageCacheTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C07ABE39613B18398CDF899E /* CR_ImageCacheTests.m */; };
 		C07ABADD3A4C59D7ACCC39CB /* CR_DisplaySizeInjector.h in Headers */ = {isa = PBXBuildFile; fileRef = C07ABE649A8AE6559CD8D6D1 /* CR_DisplaySizeInjector.h */; };
 		C07ABC0F6A8997CD78597D6B /* CR_ImageCache.m in Sources */ = {isa = PBXBuildFile; fileRef = C07AB7ACB684AE677947D589 /* CR_ImageCache.m */; };
+		C07ABC27F834AD2EEADE400F /* CR_RemoteLogRecord.m in Sources */ = {isa = PBXBuildFile; fileRef = C07AB8BF2845E5F7C18F9BBC /* CR_RemoteLogRecord.m */; };
 		C07ABC5F0E8E39C7BA6F6E7D /* CRMediaContent+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = C07AB31126BE08B645463204 /* CRMediaContent+Internal.h */; };
 		C07ABD043F2FB9DE5422FB35 /* CREmailHasher.h in Headers */ = {isa = PBXBuildFile; fileRef = C07ABD5CBBB56F796578DD76 /* CREmailHasher.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C07ABD165AFA5B3044B8AAD3 /* CR_RemoteConfigRequestTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C07AB63817F4AC10B390B880 /* CR_RemoteConfigRequestTests.m */; };
@@ -318,6 +322,7 @@
 		C07ABE08CDD58B26FFCCBCE1 /* NSUserDefaults+CR_Config.h in Headers */ = {isa = PBXBuildFile; fileRef = C07ABA8D45D123659567CEF2 /* NSUserDefaults+CR_Config.h */; };
 		C07ABE4119C225312438484B /* CR_DefaultMediaDownloaderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C07ABB7F084CBEDAC1960E3C /* CR_DefaultMediaDownloaderTests.m */; };
 		C07ABEC7592E4D7732580700 /* image.jpeg in Resources */ = {isa = PBXBuildFile; fileRef = C07AB641C0857180176F2280 /* image.jpeg */; };
+		C07ABEDECA4A63ABA2E8ADCC /* CR_RemoteLogStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = C07AB7A519A1FD39F66F50D2 /* CR_RemoteLogStorage.m */; };
 		C07ABF0597CEB2DD36AE7B51 /* CR_FeedbackControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C07ABBA46FCA43B62B82A2A0 /* CR_FeedbackControllerTests.m */; };
 		CFA4C0E324487ED4003FC46B /* CR_FeedbackController.h in Headers */ = {isa = PBXBuildFile; fileRef = C07AB510AF4AF6C47D87E0F3 /* CR_FeedbackController.h */; };
 		DF367C8A232974210044807B /* CRNativeAdUnit.h in Headers */ = {isa = PBXBuildFile; fileRef = DF367C84232971810044807B /* CRNativeAdUnit.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -684,6 +689,7 @@
 		8702B3BA4117B77A890D5F06 /* Pods-CriteoPublisherSdk.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CriteoPublisherSdk.debug.xcconfig"; path = "Target Support Files/Pods-CriteoPublisherSdk/Pods-CriteoPublisherSdk.debug.xcconfig"; sourceTree = "<group>"; };
 		92039F91AE1122C08CF8EC36 /* libPods-CriteoPublisherSdkTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-CriteoPublisherSdkTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C07AB093A865F67283614A5D /* CRMediaView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CRMediaView.m; sourceTree = "<group>"; };
+		C07AB0F74CBE74DC33F6ED1C /* CR_RemoteLogRecordTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CR_RemoteLogRecordTests.m; path = Logging/CR_RemoteLogRecordTests.m; sourceTree = "<group>"; };
 		C07AB14CF52484595D6E0E51 /* CRUserData+Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "CRUserData+Internal.h"; sourceTree = "<group>"; };
 		C07AB1709D918AD4DA7A4384 /* NSUserDefaults+CR_Config.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSUserDefaults+CR_Config.m"; sourceTree = "<group>"; };
 		C07AB1A6DF0183C472138E98 /* NSUserDefaults+Testing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSUserDefaults+Testing.h"; sourceTree = "<group>"; };
@@ -702,10 +708,13 @@
 		C07AB641C0857180176F2280 /* image.jpeg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = image.jpeg; sourceTree = "<group>"; };
 		C07AB6B9B8574FF066090C64 /* CR_InternalContextProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CR_InternalContextProvider.h; sourceTree = "<group>"; };
 		C07AB7277BC095D4A7DF86E2 /* CR_FeedbackFeatureGuard.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CR_FeedbackFeatureGuard.m; sourceTree = "<group>"; };
+		C07AB7A519A1FD39F66F50D2 /* CR_RemoteLogStorage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CR_RemoteLogStorage.m; sourceTree = "<group>"; };
 		C07AB7ACB684AE677947D589 /* CR_ImageCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CR_ImageCache.m; sourceTree = "<group>"; };
+		C07AB8BF2845E5F7C18F9BBC /* CR_RemoteLogRecord.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CR_RemoteLogRecord.m; sourceTree = "<group>"; };
 		C07AB8E611CB1C503E117386 /* CR_InternalContextProvider.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CR_InternalContextProvider.m; sourceTree = "<group>"; };
 		C07AB967F5DA5C6504960784 /* CRMediaView+Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "CRMediaView+Internal.h"; sourceTree = "<group>"; };
 		C07AB975B941355236DA96C7 /* CR_UserDataHolder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CR_UserDataHolder.m; sourceTree = "<group>"; };
+		C07AB97FE6D2C0F49B55316F /* CR_RemoteLogRecord.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CR_RemoteLogRecord.h; sourceTree = "<group>"; };
 		C07AB9F9A3CAB239567053D2 /* CRUserData.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CRUserData.m; sourceTree = "<group>"; };
 		C07ABA1B386190CDE12F3853 /* CR_UserDataHolder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CR_UserDataHolder.h; sourceTree = "<group>"; };
 		C07ABA8D45D123659567CEF2 /* NSUserDefaults+CR_Config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSUserDefaults+CR_Config.h"; sourceTree = "<group>"; };
@@ -716,6 +725,7 @@
 		C07ABB7F084CBEDAC1960E3C /* CR_DefaultMediaDownloaderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CR_DefaultMediaDownloaderTests.m; sourceTree = "<group>"; };
 		C07ABBA46FCA43B62B82A2A0 /* CR_FeedbackControllerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CR_FeedbackControllerTests.m; sourceTree = "<group>"; };
 		C07ABBC696D95F756547DA86 /* CR_NativeAssets+Testing.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "CR_NativeAssets+Testing.m"; path = "Native/CR_NativeAssets+Testing.m"; sourceTree = "<group>"; };
+		C07ABBECE75DACD69AC68FCE /* CR_RemoteLogStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CR_RemoteLogStorage.h; sourceTree = "<group>"; };
 		C07ABBFC2256322A8A934EF7 /* CriteoTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CriteoTests.m; sourceTree = "<group>"; };
 		C07ABC983FB1DA60294D238A /* CR_FeedbackController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CR_FeedbackController.m; sourceTree = "<group>"; };
 		C07ABCED19D15ED05D88A0E9 /* image.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = image.png; sourceTree = "<group>"; };
@@ -924,6 +934,10 @@
 				46C403DE257682D200E5179C /* CR_Logging.m */,
 				46C403E82577BADD00E5179C /* CR_LogMessage.h */,
 				46C403E92577BADD00E5179C /* CR_LogMessage.m */,
+				C07AB8BF2845E5F7C18F9BBC /* CR_RemoteLogRecord.m */,
+				C07AB97FE6D2C0F49B55316F /* CR_RemoteLogRecord.h */,
+				C07AB7A519A1FD39F66F50D2 /* CR_RemoteLogStorage.m */,
+				C07ABBECE75DACD69AC68FCE /* CR_RemoteLogStorage.h */,
 			);
 			path = Logging;
 			sourceTree = "<group>";
@@ -1171,6 +1185,7 @@
 				C07AB4BAE67CF9EC778F3E5C /* CR_DisplaySizeInjectorTests.m */,
 				C07ABBFC2256322A8A934EF7 /* CriteoTests.m */,
 				C07AB453C94D3281C37F5D6F /* Context */,
+				C07AB0F74CBE74DC33F6ED1C /* CR_RemoteLogRecordTests.m */,
 			);
 			path = UnitTests;
 			sourceTree = "<group>";
@@ -1682,6 +1697,8 @@
 				C07ABD043F2FB9DE5422FB35 /* CREmailHasher.h in Headers */,
 				C07AB8CAC5AA0D8D9A3B9764 /* CRContextData+Internal.h in Headers */,
 				C07AB4CE4013B32DB94E9BBC /* CR_InternalContextProvider.h in Headers */,
+				C07AB9BD9115E79936C90A99 /* CR_RemoteLogRecord.h in Headers */,
+				C07AB80BC9B93DC2ADC387F0 /* CR_RemoteLogStorage.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1986,6 +2003,8 @@
 				C07AB14F9DCFC0B80FADB2F1 /* CR_UserDataHolder.m in Sources */,
 				C07AB3BECD246E49571BD23B /* CREmailHasher.m in Sources */,
 				C07AB6FAFCA3CA34578C1C5A /* CR_InternalContextProvider.m in Sources */,
+				C07ABC27F834AD2EEADE400F /* CR_RemoteLogRecord.m in Sources */,
+				C07ABEDECA4A63ABA2E8ADCC /* CR_RemoteLogStorage.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2141,6 +2160,7 @@
 				C07ABD5E2525465AACD00E14 /* CREmailHasherTests.m in Sources */,
 				C07ABA81538D9921BFBA301F /* CR_ContextualFunctionalTests.m in Sources */,
 				C07ABD1661BCAFAD66713D81 /* CR_InternalContextProviderTests.m in Sources */,
+				C07AB6D02AA13693FEFF215F /* CR_RemoteLogRecordTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/CriteoPublisherSdk/Sources/Logging/CR_RemoteLogRecord.h
+++ b/CriteoPublisherSdk/Sources/Logging/CR_RemoteLogRecord.h
@@ -1,0 +1,40 @@
+//
+//  CR_RemoteLogRecord.h
+//  CriteoPublisherSdk
+//
+//  Copyright © 2018-2021 Criteo. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+#import "CR_Logging.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface CR_RemoteLogRecord : NSObject <NSSecureCoding>
+
+// TODO add: version, bundleId, deviceId, sessionId, profileId
+@property(nonatomic, readonly, copy) NSString *tag;
+@property(nonatomic, readonly, assign) CR_LogSeverity severity;
+@property(nonatomic, readonly, copy) NSString *message;
+@property(nonatomic, readonly, copy, nullable) NSString *exceptionType;
+
+- (instancetype)initWithTag:(NSString *)tag
+                   severity:(CR_LogSeverity)severity
+                    message:(NSString *)message
+              exceptionType:(NSString *_Nullable)exceptionType;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/CriteoPublisherSdk/Sources/Logging/CR_RemoteLogRecord.m
+++ b/CriteoPublisherSdk/Sources/Logging/CR_RemoteLogRecord.m
@@ -1,0 +1,62 @@
+//
+//  CR_RemoteLogRecord.m
+//  CriteoPublisherSdk
+//
+//  Copyright © 2018-2021 Criteo. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import "CR_RemoteLogRecord.h"
+
+@implementation CR_RemoteLogRecord
+
+- (instancetype)initWithTag:(NSString *)tag
+                   severity:(CR_LogSeverity)severity
+                    message:(NSString *)message
+              exceptionType:(NSString *_Nullable)exceptionType {
+  self = [super init];
+  if (self) {
+    _tag = tag;
+    _severity = severity;
+    _message = message;
+    _exceptionType = exceptionType;
+  }
+
+  return self;
+}
+
+- (instancetype)initWithCoder:(NSCoder *)coder {
+  self = [super init];
+  if (self) {
+    _tag = [coder decodeObjectOfClass:NSString.class forKey:@"_tag"];
+    _severity = (CR_LogSeverity)[coder decodeIntForKey:@"_severity"];
+    _message = [coder decodeObjectOfClass:NSString.class forKey:@"_message"];
+    _exceptionType = [coder decodeObjectOfClass:NSString.class forKey:@"_exceptionType"];
+  }
+
+  return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)coder {
+  [coder encodeObject:self.tag forKey:@"_tag"];
+  [coder encodeInt:(int)self.severity forKey:@"_severity"];
+  [coder encodeObject:self.message forKey:@"_message"];
+  [coder encodeObject:self.exceptionType forKey:@"_exceptionType"];
+}
+
++ (BOOL)supportsSecureCoding {
+  return YES;
+}
+
+@end

--- a/CriteoPublisherSdk/Sources/Logging/CR_RemoteLogStorage.h
+++ b/CriteoPublisherSdk/Sources/Logging/CR_RemoteLogStorage.h
@@ -1,0 +1,33 @@
+//
+//  CR_RemoteLogStorage.h
+//  CriteoPublisherSdk
+//
+//  Copyright © 2018-2021 Criteo. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+
+@class CR_RemoteLogRecord;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface CR_RemoteLogStorage : NSObject
+
+- (void)pushRemoteLogRecord:(CR_RemoteLogRecord *)remoteLogRecord;
+- (NSArray<CR_RemoteLogRecord *> *)popRemoteLogRecords;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/CriteoPublisherSdk/Sources/Logging/CR_RemoteLogStorage.m
+++ b/CriteoPublisherSdk/Sources/Logging/CR_RemoteLogStorage.m
@@ -1,0 +1,33 @@
+//
+//  CR_RemoteLogStorage.m
+//  CriteoPublisherSdk
+//
+//  Copyright © 2018-2021 Criteo. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import "CR_RemoteLogStorage.h"
+#import "CR_RemoteLogRecord.h"
+
+@implementation CR_RemoteLogStorage
+
+- (void)pushRemoteLogRecord:(CR_RemoteLogRecord *)remoteLogRecord {
+  // TODO EE-1348
+}
+
+- (NSArray<CR_RemoteLogRecord *> *)popRemoteLogRecords {
+  return @[];  // TODO EE-1348
+}
+
+@end

--- a/CriteoPublisherSdk/Tests/UnitTests/Logging/CR_RemoteLogRecordTests.m
+++ b/CriteoPublisherSdk/Tests/UnitTests/Logging/CR_RemoteLogRecordTests.m
@@ -1,0 +1,47 @@
+//
+//  CR_RemoteLogRecordTests.m
+//  CriteoPublisherSdk
+//
+//  Copyright © 2018-2021 Criteo. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import <XCTest/XCTest.h>
+#import "CR_RemoteLogRecord.h"
+
+@interface CR_RemoteLogRecordTests : XCTestCase
+@end
+
+@implementation CR_RemoteLogRecordTests
+
+- (void)testEncoding {
+  CR_RemoteLogRecord *remoteLogRecord = [[CR_RemoteLogRecord alloc] initWithTag:@"myTag"
+                                                                       severity:CR_LogSeverityDebug
+                                                                        message:@"myMessage"
+                                                                  exceptionType:@"myExceptionType"];
+
+  CR_RemoteLogRecord *unarchivedRecord = [self archiveAndUnarchiveRemoteLogRecord:remoteLogRecord];
+
+  XCTAssertEqualObjects(unarchivedRecord.tag, remoteLogRecord.tag);
+  XCTAssertEqual(unarchivedRecord.severity, remoteLogRecord.severity);
+  XCTAssertEqualObjects(unarchivedRecord.message, remoteLogRecord.message);
+  XCTAssertEqualObjects(unarchivedRecord.exceptionType, remoteLogRecord.exceptionType);
+}
+
+- (CR_RemoteLogRecord *)archiveAndUnarchiveRemoteLogRecord:(CR_RemoteLogRecord *)remoteLogRecord {
+  NSData *data = [NSKeyedArchiver archivedDataWithRootObject:remoteLogRecord];
+  return [NSKeyedUnarchiver unarchiveObjectWithData:data];
+}
+
+@end


### PR DESCRIPTION
This adds an intermediary storage interface from which we can work in parallel on:
* EE-1352: Setup remote log handler filtering log based on log level
* EE-1348: Persistence of remote log
* EE-1350: Serialization and sending of remote log request to backend