### PR TITLE
feat(DPP-3746): allow empty constructor usage for `CRBannerView`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Criteo Publisher SDK Changelog
 --------------------------------------------------------------------------------
+
+## Version 4.5.0
+
+### Fixes
+ - **In house**: allow init of `CRBannerView` without specifying the adUnitId
+
+--------------------------------------------------------------------------------
 ## Version 4.4.0
 
 ### Features

--- a/CriteoAdViewer/Sources/AdViewer/CriteoAdViewBuilder.swift
+++ b/CriteoAdViewer/Sources/AdViewer/CriteoAdViewBuilder.swift
@@ -47,12 +47,15 @@ class CriteoAdViewBuilder: AdViewBuilder {
   }
 
   private func buildBanner(_ adUnit: CRBannerAdUnit, _ criteo: Criteo) -> CRBannerView {
-    let adView = CRBannerView(adUnit: adUnit, criteo: criteo)!
-    adView.delegate = logger
+    var adView: CRBannerView
     switch adType {
     case .standalone:
+      adView = CRBannerView(adUnit: adUnit, criteo: criteo)!
+      adView.delegate = logger
       adView.loadAd(withContext: contextData)
     case .inHouse:
+      adView = CRBannerView()
+      adView.delegate = logger
       criteo.loadBid(for: adUnit, withContext: contextData) { maybeBid in
         if let bid = maybeBid {
           adView.loadAd(with: bid)
@@ -64,12 +67,15 @@ class CriteoAdViewBuilder: AdViewBuilder {
 
   private func buildInterstitial(_ adUnit: CRInterstitialAdUnit, _ criteo: Criteo) -> CRInterstitial
   {
-    let adView = CRInterstitial(adUnit: adUnit, criteo: criteo)!
-    adView.delegate = logger
+    var adView: CRInterstitial
     switch adType {
     case .standalone:
+      adView = CRInterstitial(adUnit: adUnit, criteo: criteo)!
+      adView.delegate = logger
       adView.loadAd(withContext: contextData)
     case .inHouse:
+      adView = CRInterstitial()
+      adView.delegate = logger
       criteo.loadBid(for: adUnit, withContext: contextData) { maybeBid in
         if let bid = maybeBid {
           adView.loadAd(with: bid)

--- a/CriteoAdViewer/Sources/AdViewer/MopubAdViewBuilder.swift
+++ b/CriteoAdViewer/Sources/AdViewer/MopubAdViewBuilder.swift
@@ -74,7 +74,7 @@ class MopubAdViewBuilder: AdViewBuilder {
   private func load(_ ad: MPLoadableAd, config: AdConfig, criteo: Criteo) {
     let criteoAdUnitId: CRAdUnit
     if config.adFormat == .flexible(.video) {
-        // need to use a specific adUnitId to be able to load video ads properly
+      // need to use a specific adUnitId to be able to load video ads properly
       criteoAdUnitId = CRInterstitialAdUnit(
         adUnitId: "/140800857/Endeavour_InterstitialVideo_320x480")
     } else {

--- a/CriteoPublisherSdk/Sources/CRBid+Internal.h
+++ b/CriteoPublisherSdk/Sources/CRBid+Internal.h
@@ -21,6 +21,8 @@
 #define CRBid_Internal_h
 
 #import <CriteoPublisherSdk/CRBid.h>
+#import "CRAdUnit.h"
+#import "CRAdUnit+Internal.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -34,6 +36,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, strong) CR_CdbBid *_Nullable cdbBid;
 
 - (instancetype)initWithCdbBid:(CR_CdbBid *)cdbBid adUnit:(CRAdUnit *)adUnit;
+
+- (CR_CdbBid *)consumeFor:(CRAdUnitType)type;
 
 - (CR_CdbBid *_Nullable)consume;
 

--- a/CriteoPublisherSdk/Sources/CRBid.m
+++ b/CriteoPublisherSdk/Sources/CRBid.m
@@ -17,6 +17,8 @@
 // limitations under the License.
 //
 
+#import "CRAdUnit.h"
+#import "CRAdUnit+Internal.h"
 #import "CRBid+Internal.h"
 #import "CR_CdbBid.h"
 
@@ -29,6 +31,13 @@
     _cdbBid = cdbBid;
   }
   return self;
+}
+
+- (CR_CdbBid *)consumeFor:(CRAdUnitType)type {
+  if (type == self.adUnit.adUnitType) {
+    return [self consume];
+  }
+  return nil;
 }
 
 - (CR_CdbBid *)consume {

--- a/CriteoPublisherSdk/Sources/Standalone/CRBannerView.m
+++ b/CriteoPublisherSdk/Sources/Standalone/CRBannerView.m
@@ -38,6 +38,10 @@
 
 @implementation CRBannerView
 
+- (instancetype)init {
+  return [self initWithAdUnit:[CRBannerAdUnit alloc]];
+}
+
 - (instancetype)initWithAdUnit:(CRBannerAdUnit *)adUnit {
   return [self initWithAdUnit:adUnit criteo:[Criteo sharedCriteo]];
 }
@@ -159,11 +163,16 @@
     return;
   }
 
-  CR_CdbBid *cdbBid = bid.consume;
+  CR_CdbBid *cdbBid = [bid consumeFor:CRAdUnitTypeBanner];
   if (!cdbBid) {
     [self safelyNotifyAdLoadFail:CRErrorCodeNoFill];
     return;
   }
+
+  CGFloat width = [cdbBid.width floatValue];
+  CGFloat height = [cdbBid.height floatValue];
+  self.frame = CGRectMake(0, 0, width, height);
+  self.webView.frame = CGRectMake(0, 0, width, height);
 
   [self loadAdWithCdbBid:cdbBid];
 }

--- a/CriteoPublisherSdk/Sources/Standalone/CRInterstitial.m
+++ b/CriteoPublisherSdk/Sources/Standalone/CRInterstitial.m
@@ -59,6 +59,10 @@
   return self;
 }
 
+- (instancetype)init {
+  return [self initWithAdUnit:[CRInterstitialAdUnit alloc]];
+}
+
 - (instancetype)initWithAdUnit:(CRInterstitialAdUnit *)adUnit {
   return [self initWithAdUnit:adUnit criteo:[Criteo sharedCriteo]];
 }
@@ -177,7 +181,7 @@
     return;
   }
 
-  CR_CdbBid *cdbBid = bid.consume;
+  CR_CdbBid *cdbBid = [bid consumeFor:CRAdUnitTypeInterstitial];
   if (!cdbBid) {
     [self safelyNotifyAdLoadFail:CRErrorCodeNoFill];
     self.isAdLoading = NO;

--- a/CriteoPublisherSdk/Tests/IntegrationTests/CR_StandaloneBannerFunctionalTests.m
+++ b/CriteoPublisherSdk/Tests/IntegrationTests/CR_StandaloneBannerFunctionalTests.m
@@ -76,13 +76,13 @@ static NSString *creativeUrl2 = @"www.apple.com";
   CR_CreativeViewChecker *viewChecker = [[CR_CreativeViewChecker alloc] initWithAdUnit:banner
                                                                                 criteo:self.criteo];
 
-  [viewChecker injectBidWithExpectedCreativeUrl:creativeUrl1];
+  [viewChecker injectBidWithExpectedCreativeUrl:creativeUrl1 forAdUnit:banner];
   [viewChecker.bannerView loadAdWithContext:self.contextData];
   [self cr_waitForExpectations:@[ viewChecker.adCreativeRenderedExpectation ]];
 
   [viewChecker resetExpectations];
 
-  [viewChecker injectBidWithExpectedCreativeUrl:creativeUrl2];
+  [viewChecker injectBidWithExpectedCreativeUrl:creativeUrl2 forAdUnit:banner];
   [viewChecker.bannerView loadAdWithContext:self.contextData];
   [self cr_waitForExpectations:@[ viewChecker.adCreativeRenderedExpectation ]];
 }
@@ -93,14 +93,14 @@ static NSString *creativeUrl2 = @"www.apple.com";
   CR_CreativeViewChecker *viewChecker = [[CR_CreativeViewChecker alloc] initWithAdUnit:banner
                                                                                 criteo:self.criteo];
 
-  [viewChecker injectBidWithExpectedCreativeUrl:creativeUrl1];
+  [viewChecker injectBidWithExpectedCreativeUrl:creativeUrl1 forAdUnit:banner];
   [viewChecker.bannerView loadAdWithContext:self.contextData];
   [self cr_waitForExpectations:@[ viewChecker.adCreativeRenderedExpectation ]];
 
   [viewChecker resetExpectations];
   [viewChecker resetBannerView];
 
-  [viewChecker injectBidWithExpectedCreativeUrl:creativeUrl2];
+  [viewChecker injectBidWithExpectedCreativeUrl:creativeUrl2 forAdUnit:banner];
   [viewChecker.bannerView loadAdWithContext:self.contextData];
   [self cr_waitForExpectations:@[ viewChecker.adCreativeRenderedExpectation ]];
 }
@@ -112,7 +112,7 @@ static NSString *creativeUrl2 = @"www.apple.com";
   CR_CreativeViewChecker *viewChecker = [[CR_CreativeViewChecker alloc] initWithAdUnit:banner
                                                                                 criteo:self.criteo];
 
-  [viewChecker injectBidWithAppStoreClickUrl];
+  [viewChecker injectBidWithAppStoreClickUrl:banner];
   [viewChecker.bannerView loadAdWithContext:self.contextData];
 
   [self cr_waitForExpectations:@[ viewChecker.adCreativeRenderedExpectation ]];

--- a/CriteoPublisherSdk/Tests/Utility/Checkers/CR_CreativeViewChecker.h
+++ b/CriteoPublisherSdk/Tests/Utility/Checkers/CR_CreativeViewChecker.h
@@ -28,6 +28,8 @@
 
 - (instancetype)init NS_UNAVAILABLE;
 
+- (instancetype)initWithCriteo:(Criteo *)criteo;
+
 - (instancetype)initWithAdUnit:(CRAdUnit *)adUnit criteo:(Criteo *)criteo;
 
 @property(strong, nonatomic, readonly) UIWindow *uiWindow;
@@ -44,9 +46,9 @@
 
 - (void)resetBannerView;
 
-- (void)injectBidWithExpectedCreativeUrl:(NSString *)creativeUrl;
+- (void)injectBidWithExpectedCreativeUrl:(NSString *)creativeUrl forAdUnit:(CRAdUnit *)adUnit;
 
-- (void)injectBidWithAppStoreClickUrl;
+- (void)injectBidWithAppStoreClickUrl:(CRAdUnit *)adUnit;
 - (void)clickUrl;
 
 @end


### PR DESCRIPTION
Allow to use empty constructor to init `CRBannerView`

Adjusted behavior so that CRBannerView does not require adUnitId set on init but get it from the bid. Made the sample app use this for inHouse showcase.

Fixes DPP-3746