### PR TITLE
DPP-4090 Add COPPA support to iOS Publisher SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Features
 - Remove MoPub header bidding support
+- Add ability to set Children's Online Privacy Protection Act ("COPPA") flag
 
 ### MoPub Adapter
 - remove MoPub adapter support

--- a/CriteoAdViewer/Sources/AdViewer/AdViewerViewController.swift
+++ b/CriteoAdViewer/Sources/AdViewer/AdViewerViewController.swift
@@ -29,7 +29,7 @@ class AdViewerViewController: FormViewController {
 
   // MARK: form helper properties
   private enum Tags: String {
-    case network, type, size, display, ads, publisherId
+    case network, type, size, display, ads, publisherId, childDirectedTreatment
   }
 
   private enum DisplayMode: CustomStringConvertible {
@@ -43,6 +43,25 @@ class AdViewerViewController: FormViewController {
       switch self {
       case .onScreen: return "Below"
       case .newView: return "New View"
+      }
+    }
+  }
+
+  private enum ChildDirectedTreatment: CustomStringConvertible {
+
+    case absent
+    case active
+    case inactive
+
+    static func all() -> Array<ChildDirectedTreatment> {
+      return [.absent, .active, .inactive]
+    }
+
+    var description: String {
+      switch self {
+      case .absent: return "Absent"
+      case .active: return "True"
+      case .inactive: return "False"
       }
     }
   }
@@ -61,6 +80,9 @@ class AdViewerViewController: FormViewController {
   }
   private var display: DisplayMode? {
     self.values[Tags.display.rawValue] as? DisplayMode
+  }
+  private var childDirectedTreatment: ChildDirectedTreatment? {
+    self.values[Tags.childDirectedTreatment.rawValue] as? ChildDirectedTreatment
   }
 
   override func viewDidLoad() {
@@ -106,6 +128,13 @@ class AdViewerViewController: FormViewController {
         $0.onChange { _ in
           self.updateAdConfig()
         }
+      }
+      <<< SegmentedRow<ChildDirectedTreatment>(Tags.childDirectedTreatment.rawValue) {
+        $0.displayValueFor = { $0?.description }
+        $0.options = ChildDirectedTreatment.all()
+        $0.onChange { [weak self] _ in self?.updateChildDirectedTreatment() }
+        $0.title = "Coppa"
+        $0.value = $0.options?.first
       }
   }
 
@@ -170,6 +199,17 @@ class AdViewerViewController: FormViewController {
     if let adConfig = buildAdConfig() {
       self.adConfig = adConfig
       self.criteo = buildCriteo(adConfig: adConfig)
+    }
+  }
+
+  private func updateChildDirectedTreatment() {
+    switch childDirectedTreatment {
+    case .active:
+      criteo?.childDirectedTreatment = NSNumber(booleanLiteral: true)
+    case .inactive:
+      criteo?.childDirectedTreatment = NSNumber(booleanLiteral: false)
+    default:
+      criteo?.childDirectedTreatment = nil
     }
   }
 

--- a/CriteoPublisherSdk/Sources/CR_BidManager.h
+++ b/CriteoPublisherSdk/Sources/CR_BidManager.h
@@ -50,6 +50,7 @@
 @property(nonatomic, readonly) CR_Config *config;
 @property(nonatomic, strong) CR_DataProtectionConsent *consent;
 @property(nonatomic, strong) CR_ThreadManager *threadManager;
+@property(nonatomic, strong) NSNumber *childDirectedTreatment;
 
 #pragma mark - Lifecycle
 

--- a/CriteoPublisherSdk/Sources/CR_BidManager.m
+++ b/CriteoPublisherSdk/Sources/CR_BidManager.m
@@ -92,6 +92,8 @@ typedef void (^CR_CdbResponseHandler)(CR_CdbResponse *response);
     _threadManager = threadManager;
     _headerBidding = headerBidding;
     _remoteLogHandler = remoteLogHandler;
+    _childDirectedTreatment = nil;  // nil is default value -> basically the same as false, but
+                                    // can't be set false because it needs to be set explicitly
   }
 
   return self;
@@ -272,6 +274,7 @@ typedef void (^CR_CdbResponseHandler)(CR_CdbResponse *response);
         config:self->config
         deviceInfo:self->deviceInfo
         context:contextData
+        childDirectedTreatment:self.childDirectedTreatment
         beforeCdbCall:^(CR_CdbRequest *cdbRequest) {
           [self beforeCdbCall:cdbRequest];
         }

--- a/CriteoPublisherSdk/Sources/Criteo.m
+++ b/CriteoPublisherSdk/Sources/Criteo.m
@@ -35,6 +35,8 @@
 
 @implementation Criteo
 
+@dynamic childDirectedTreatment;
+
 #pragma mark - Lifecycle
 
 - (void)setup {
@@ -138,6 +140,14 @@ static dispatch_once_t onceToken;
 }
 
 #pragma mark - Bidding
+
+- (NSNumber *_Nullable)childDirectedTreatment {
+  return self.bidManager.childDirectedTreatment;
+}
+
+- (void)setChildDirectedTreatment:(NSNumber *_Nullable)childDirectedTreatment {
+  self.bidManager.childDirectedTreatment = childDirectedTreatment;
+}
 
 - (void)loadBidForAdUnit:(CRAdUnit *)adUnit responseHandler:(CRBidResponseHandler)responseHandler {
   [self loadBidForAdUnit:adUnit withContext:CRContextData.new responseHandler:responseHandler];

--- a/CriteoPublisherSdk/Sources/Network/CR_ApiHandler.h
+++ b/CriteoPublisherSdk/Sources/Network/CR_ApiHandler.h
@@ -67,12 +67,13 @@ typedef void (^CR_LogsCompletionHandler)(NSError *error);
  * adUnit must have an Id, width and length.
  */
 - (void)callCdb:(CR_CacheAdUnitArray *)adUnits
-              consent:(CR_DataProtectionConsent *)consent
-               config:(CR_Config *)config
-           deviceInfo:(CR_DeviceInfo *)deviceInfo
-              context:(__unused CRContextData *)contextData
-        beforeCdbCall:(CR_BeforeCdbCall)beforeCdbCall
-    completionHandler:(CR_CdbCompletionHandler)completionHandler;
+                   consent:(CR_DataProtectionConsent *)consent
+                    config:(CR_Config *)config
+                deviceInfo:(CR_DeviceInfo *)deviceInfo
+                   context:(__unused CRContextData *)contextData
+    childDirectedTreatment:(NSNumber *)childDirectedTreatment
+             beforeCdbCall:(CR_BeforeCdbCall)beforeCdbCall
+         completionHandler:(CR_CdbCompletionHandler)completionHandler;
 
 /**
  * Builds the CDB response for given Data. This method is intended to mock responses.

--- a/CriteoPublisherSdk/Sources/Network/CR_ApiHandler.m
+++ b/CriteoPublisherSdk/Sources/Network/CR_ApiHandler.m
@@ -92,21 +92,23 @@ static NSUInteger const maxAdUnitsPerCdbRequest = 8;
 
 // Wrapper method to make the cdb call async
 - (void)callCdb:(CR_CacheAdUnitArray *)adUnits
-              consent:(CR_DataProtectionConsent *)consent
-               config:(CR_Config *)config
-           deviceInfo:(CR_DeviceInfo *)deviceInfo
-              context:(CRContextData *)contextData
-        beforeCdbCall:(CR_BeforeCdbCall)beforeCdbCall
-    completionHandler:(CR_CdbCompletionHandler)completionHandler {
+                   consent:(CR_DataProtectionConsent *)consent
+                    config:(CR_Config *)config
+                deviceInfo:(CR_DeviceInfo *)deviceInfo
+                   context:(CRContextData *)contextData
+    childDirectedTreatment:(NSNumber *)childDirectedTreatment
+             beforeCdbCall:(CR_BeforeCdbCall)beforeCdbCall
+         completionHandler:(CR_CdbCompletionHandler)completionHandler {
   [self.threadManager dispatchAsyncOnGlobalQueue:^{
     @try {
       [self doCdbApiCall:adUnits
-                    consent:consent
-                     config:config
-                 deviceInfo:deviceInfo
-                    context:contextData
-              beforeCdbCall:(CR_BeforeCdbCall)beforeCdbCall
-          completionHandler:completionHandler];
+                         consent:consent
+                          config:config
+                      deviceInfo:deviceInfo
+                         context:contextData
+          childDirectedTreatment:childDirectedTreatment
+                   beforeCdbCall:(CR_BeforeCdbCall)beforeCdbCall
+               completionHandler:completionHandler];
     } @catch (NSException *exception) {
       CRLogException(@"BidRequest", exception, @"Failed requesting bid");
     }
@@ -115,12 +117,13 @@ static NSUInteger const maxAdUnitsPerCdbRequest = 8;
 
 // Method that makes the actual call to CDB
 - (void)doCdbApiCall:(CR_CacheAdUnitArray *)adUnits
-              consent:(CR_DataProtectionConsent *)consent
-               config:(CR_Config *)config
-           deviceInfo:(CR_DeviceInfo *)deviceInfo
-              context:(CRContextData *)contextData
-        beforeCdbCall:(CR_BeforeCdbCall)beforeCdbCall
-    completionHandler:(CR_CdbCompletionHandler)completionHandler {
+                   consent:(CR_DataProtectionConsent *)consent
+                    config:(CR_Config *)config
+                deviceInfo:(CR_DeviceInfo *)deviceInfo
+                   context:(CRContextData *)contextData
+    childDirectedTreatment:(NSNumber *)childDirectedTreatment
+             beforeCdbCall:(CR_BeforeCdbCall)beforeCdbCall
+         completionHandler:(CR_CdbCompletionHandler)completionHandler {
   CR_CacheAdUnitArray *requestAdUnits = [self filterRequestAdUnitsAndSetProgressFlags:adUnits];
   if (requestAdUnits.count == 0) {
     return;
@@ -142,7 +145,8 @@ static NSUInteger const maxAdUnitsPerCdbRequest = 8;
                                                                consent:consent
                                                                 config:config
                                                             deviceInfo:deviceInfo
-                                                               context:contextData];
+                                                               context:contextData
+                                                childDirectedTreatment:childDirectedTreatment];
     [self.networkManager postToUrl:url
                               body:body
                         logWithTag:@"BidRequest"

--- a/CriteoPublisherSdk/Sources/Network/CR_ApiQueryKeys.h
+++ b/CriteoPublisherSdk/Sources/Network/CR_ApiQueryKeys.h
@@ -19,6 +19,8 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface CR_ApiQueryKeys : NSObject
 
 @property(class, nonatomic, readonly) NSString *appId;
@@ -76,5 +78,11 @@
 @property(class, nonatomic, readonly) NSString *uspCriteoOptout;
 @property(class, nonatomic, readonly) NSString *wrapperVersion;
 @property(class, nonatomic, readonly) NSString *zoneId;
+@property(class, nonatomic, readonly) NSString *regs;
+
+/// Used to map childDirectedTreatment property.
+@property(class, nonatomic, readonly) NSString *coppa;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/CriteoPublisherSdk/Sources/Network/CR_ApiQueryKeys.m
+++ b/CriteoPublisherSdk/Sources/Network/CR_ApiQueryKeys.m
@@ -159,5 +159,11 @@
 + (NSString *)zoneId {
   return @"zoneId";
 }
++ (NSString *)regs {
+  return @"regs";
+}
++ (NSString *)coppa {
+  return @"coppa";
+}
 
 @end

--- a/CriteoPublisherSdk/Sources/Network/Serializers/CR_BidRequestSerializer.h
+++ b/CriteoPublisherSdk/Sources/Network/Serializers/CR_BidRequestSerializer.h
@@ -46,7 +46,8 @@ NS_ASSUME_NONNULL_BEGIN
                              consent:(CR_DataProtectionConsent *)consent
                               config:(CR_Config *)config
                           deviceInfo:(CR_DeviceInfo *)deviceInfo
-                             context:(CRContextData *)contextData;
+                             context:(CRContextData *)contextData
+              childDirectedTreatment:(NSNumber *_Nullable)childDirectedTreatment;
 
 #pragma mark - Private but unit-tested (To be refactored)
 

--- a/CriteoPublisherSdk/Sources/Network/Serializers/CR_BidRequestSerializer.m
+++ b/CriteoPublisherSdk/Sources/Network/Serializers/CR_BidRequestSerializer.m
@@ -72,7 +72,8 @@
                              consent:(CR_DataProtectionConsent *)consent
                               config:(CR_Config *)config
                           deviceInfo:(CR_DeviceInfo *)deviceInfo
-                             context:(CRContextData *)contextData {
+                             context:(CRContextData *)contextData
+              childDirectedTreatment:(NSNumber *)childDirectedTreatment {
   NSMutableDictionary *postBody = [NSMutableDictionary new];
   postBody[CR_ApiQueryKeys.sdkVersion] = config.sdkVersion;
   postBody[CR_ApiQueryKeys.profileId] = cdbRequest.profileId;
@@ -83,6 +84,11 @@
   postBody[CR_ApiQueryKeys.user] = [self userWithConsent:consent
                                                   config:config
                                               deviceInfo:deviceInfo];
+  if (childDirectedTreatment != nil) {
+    postBody[CR_ApiQueryKeys.regs] = [NSDictionary dictionaryWithObject:childDirectedTreatment
+                                                                 forKey:CR_ApiQueryKeys.coppa];
+  }
+
   return postBody;
 }
 

--- a/CriteoPublisherSdk/Sources/Public/Criteo.h
+++ b/CriteoPublisherSdk/Sources/Public/Criteo.h
@@ -74,6 +74,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Bidding
 
+/// Set to true if you think that your mobile app is intended specifically for children, so we treat
+/// bidding as child-directed in whole or in part for the purposes of the Children's Online Privacy
+/// Protection Act (COPPA).
+@property(nonatomic) NSNumber *_Nullable childDirectedTreatment;
+
 /**
  * Request asynchronously a bid from Criteo
  * @param adUnit The ad unit to request

--- a/CriteoPublisherSdk/Tests/CriteoPublisherSdkTests-Bridging-Header.h
+++ b/CriteoPublisherSdk/Tests/CriteoPublisherSdkTests-Bridging-Header.h
@@ -4,6 +4,7 @@
 //
 
 #import "CR_ApiHandler.h"
+#import "CR_ApiQueryKeys.h"
 #import "CR_BidManager.h"
 #import "CR_BidManager+Testing.h"
 #import "CR_BidRequestSerializer.h"

--- a/CriteoPublisherSdk/Tests/UnitTests/CR_BidManagerFeedbackTests.m
+++ b/CriteoPublisherSdk/Tests/UnitTests/CR_BidManagerFeedbackTests.m
@@ -500,6 +500,7 @@
                                 config:[OCMArg any]
                             deviceInfo:[OCMArg any]
                                context:[OCMArg any]
+                childDirectedTreatment:[OCMArg any]
                          beforeCdbCall:beforeCdbCall
                      completionHandler:completion]);
 }
@@ -511,6 +512,7 @@
                                 config:[OCMArg any]
                             deviceInfo:[OCMArg any]
                                context:[OCMArg any]
+                childDirectedTreatment:[OCMArg any]
                          beforeCdbCall:beforeCdbCall
                      completionHandler:[OCMArg any]]);
 }

--- a/CriteoPublisherSdk/Tests/UnitTests/Mocks/CR_ApiHandlerMock.swift
+++ b/CriteoPublisherSdk/Tests/UnitTests/Mocks/CR_ApiHandlerMock.swift
@@ -38,7 +38,7 @@ class CR_ApiHandlerMock: CR_ApiHandler {
   var callCdbBeforeCdbResponseBlock: (() -> Void)?
   var callCdbCdbResponse: CR_CdbResponse?
 
-  override func callCdb(_ adUnits: [CR_CacheAdUnit]!, consent: CR_DataProtectionConsent!, config: CR_Config!, deviceInfo: CR_DeviceInfo!, context contextData: CRContextData!, beforeCdbCall: CR_BeforeCdbCall!, completionHandler: CR_CdbCompletionHandler!) {
+  override func callCdb(_ adUnits: [CR_CacheAdUnit]!, consent: CR_DataProtectionConsent!, config: CR_Config!, deviceInfo: CR_DeviceInfo!, context contextData: CRContextData!, childDirectedTreatment: NSNumber!, beforeCdbCall: CR_BeforeCdbCall!, completionHandler: CR_CdbCompletionHandler!) {
     callCdbWasCalled = true
     callCdbAdUnits = adUnits
     callCdbBeforeCdbResponseBlock?()

--- a/CriteoPublisherSdk/Tests/UnitTests/Network/CR_ApiHandlerTests.m
+++ b/CriteoPublisherSdk/Tests/UnitTests/Network/CR_ApiHandlerTests.m
@@ -88,26 +88,27 @@
   CR_CdbBid *testBid_1 = [self buildEuroBid];
   XCTestExpectation *expectation = [self expectationWithDescription:@"CDB call expectation"];
 
-  [self.apiHandler
-                callCdb:@[ [self buildCacheAdUnit] ]
-                consent:self.consentMock
-                 config:self.configMock
-             deviceInfo:self.deviceInfoMock
-                context:self.contextData
-          beforeCdbCall:nil
-      completionHandler:^(CR_CdbRequest *cdbRequest, CR_CdbResponse *cdbResponse, NSError *error) {
-        XCTAssertNil(nil);
-        XCTAssertNotNil(cdbResponse.cdbBids);
-        NSLog(@"Data length is %lu", (unsigned long)[cdbResponse.cdbBids count]);
-        XCTAssertEqual(1, [cdbResponse.cdbBids count]);
-        CR_CdbBid *receivedBid = cdbResponse.cdbBids[0];
-        XCTAssertEqualObjects(testBid_1.placementId, receivedBid.placementId);
-        XCTAssertEqualObjects(testBid_1.width, receivedBid.width);
-        XCTAssertEqualObjects(testBid_1.height, receivedBid.height);
-        XCTAssertEqualObjects(testBid_1.cpm, receivedBid.cpm);
-        XCTAssertEqual(testBid_1.ttl, receivedBid.ttl);
-        [expectation fulfill];
-      }];
+  [self.apiHandler callCdb:@[ [self buildCacheAdUnit] ]
+                     consent:self.consentMock
+                      config:self.configMock
+                  deviceInfo:self.deviceInfoMock
+                     context:self.contextData
+      childDirectedTreatment:nil
+               beforeCdbCall:nil
+           completionHandler:^(CR_CdbRequest *cdbRequest, CR_CdbResponse *cdbResponse,
+                               NSError *error) {
+             XCTAssertNil(nil);
+             XCTAssertNotNil(cdbResponse.cdbBids);
+             NSLog(@"Data length is %lu", (unsigned long)[cdbResponse.cdbBids count]);
+             XCTAssertEqual(1, [cdbResponse.cdbBids count]);
+             CR_CdbBid *receivedBid = cdbResponse.cdbBids[0];
+             XCTAssertEqualObjects(testBid_1.placementId, receivedBid.placementId);
+             XCTAssertEqualObjects(testBid_1.width, receivedBid.width);
+             XCTAssertEqualObjects(testBid_1.height, receivedBid.height);
+             XCTAssertEqualObjects(testBid_1.cpm, receivedBid.cpm);
+             XCTAssertEqual(testBid_1.ttl, receivedBid.ttl);
+             [expectation fulfill];
+           }];
 
   [self cr_waitForExpectations:@[ expectation ]];
 }
@@ -126,17 +127,18 @@
       [self expectationWithDescription:@"beforeCdbCall callback invoked"];
   CR_CacheAdUnit *adUnit = [self buildCacheAdUnit];
   [self.apiHandler callCdb:@[ adUnit ]
-                   consent:self.consentMock
-                    config:self.configMock
-                deviceInfo:self.deviceInfoMock
-                   context:self.contextData
-             beforeCdbCall:^(CR_CdbRequest *cdbRequest) {
-               XCTAssertNotNil(cdbRequest);
-               XCTAssertEqual(cdbRequest.adUnits.count, 1);
-               XCTAssertEqualObjects(cdbRequest.adUnits[0], adUnit);
-               [expectation fulfill];
-             }
-         completionHandler:nil];
+                     consent:self.consentMock
+                      config:self.configMock
+                  deviceInfo:self.deviceInfoMock
+                     context:self.contextData
+      childDirectedTreatment:nil
+               beforeCdbCall:^(CR_CdbRequest *cdbRequest) {
+                 XCTAssertNotNil(cdbRequest);
+                 XCTAssertEqual(cdbRequest.adUnits.count, 1);
+                 XCTAssertEqualObjects(cdbRequest.adUnits[0], adUnit);
+                 [expectation fulfill];
+               }
+           completionHandler:nil];
   [self cr_waitForExpectations:@[ expectation ]];
 }
 
@@ -170,32 +172,57 @@
   CR_CdbBid *testBid_1 = [self buildEuroBid];
   CR_CdbBid *testBid_2 = [self buildDollarBid];
   [apiHandler callCdb:@[ testAdUnit_1, testAdUnit_2 ]
-                consent:self.consentMock
-                 config:self.configMock
-             deviceInfo:self.deviceInfoMock
-                context:self.contextData
-          beforeCdbCall:nil
-      completionHandler:^(CR_CdbRequest *cdbRequest, CR_CdbResponse *cdbResponse, NSError *error) {
-        XCTAssertNotNil(cdbResponse.cdbBids);
-        NSLog(@"Data length is %lu", (unsigned long)[cdbResponse.cdbBids count]);
-        XCTAssertEqual(2, [cdbResponse.cdbBids count]);
+                     consent:self.consentMock
+                      config:self.configMock
+                  deviceInfo:self.deviceInfoMock
+                     context:self.contextData
+      childDirectedTreatment:nil
+               beforeCdbCall:nil
+           completionHandler:^(CR_CdbRequest *cdbRequest, CR_CdbResponse *cdbResponse,
+                               NSError *error) {
+             XCTAssertNotNil(cdbResponse.cdbBids);
+             NSLog(@"Data length is %lu", (unsigned long)[cdbResponse.cdbBids count]);
+             XCTAssertEqual(2, [cdbResponse.cdbBids count]);
 
-        CR_CdbBid *receivedBid1 = cdbResponse.cdbBids[0];
-        XCTAssertEqualObjects(testBid_1.placementId, receivedBid1.placementId);
-        XCTAssertEqualObjects(testBid_1.width, receivedBid1.width);
-        XCTAssertEqualObjects(testBid_1.height, receivedBid1.height);
-        XCTAssertEqualObjects(testBid_1.cpm, receivedBid1.cpm);
-        XCTAssertEqual(testBid_1.ttl, receivedBid1.ttl);
+             CR_CdbBid *receivedBid1 = cdbResponse.cdbBids[0];
+             XCTAssertEqualObjects(testBid_1.placementId, receivedBid1.placementId);
+             XCTAssertEqualObjects(testBid_1.width, receivedBid1.width);
+             XCTAssertEqualObjects(testBid_1.height, receivedBid1.height);
+             XCTAssertEqualObjects(testBid_1.cpm, receivedBid1.cpm);
+             XCTAssertEqual(testBid_1.ttl, receivedBid1.ttl);
 
-        CR_CdbBid *receivedBid2 = cdbResponse.cdbBids[1];
-        XCTAssertEqualObjects(testBid_2.placementId, receivedBid2.placementId);
-        XCTAssertEqualObjects(testBid_2.width, receivedBid2.width);
-        XCTAssertEqualObjects(testBid_2.height, receivedBid2.height);
-        XCTAssertEqualObjects(testBid_2.cpm, receivedBid2.cpm);
-        XCTAssertEqual(testBid_2.ttl, receivedBid2.ttl);
+             CR_CdbBid *receivedBid2 = cdbResponse.cdbBids[1];
+             XCTAssertEqualObjects(testBid_2.placementId, receivedBid2.placementId);
+             XCTAssertEqualObjects(testBid_2.width, receivedBid2.width);
+             XCTAssertEqualObjects(testBid_2.height, receivedBid2.height);
+             XCTAssertEqualObjects(testBid_2.cpm, receivedBid2.cpm);
+             XCTAssertEqual(testBid_2.ttl, receivedBid2.ttl);
 
-        [expectation fulfill];
-      }];
+             [expectation fulfill];
+           }];
+  [self cr_waitForExpectations:@[ expectation ]];
+}
+
+- (void)testCallCdbWithChildDirectedTreatment {
+  XCTAssertNil([self networkManagerMock].lastPostBody[CR_ApiQueryKeys.regs][CR_ApiQueryKeys.coppa]);
+  XCTestExpectation *expectation =
+      [self expectationWithDescription:@"beforeCdbCall callback invoked"];
+
+  [self.apiHandler callCdb:@[ [self buildCacheAdUnit] ]
+                     consent:self.consentMock
+                      config:self.configMock
+                  deviceInfo:self.deviceInfoMock
+                     context:self.contextData
+      childDirectedTreatment:@YES
+               beforeCdbCall:nil
+           completionHandler:^(CR_CdbRequest *cdbRequest, CR_CdbResponse *cdbResponse,
+                               NSError *error) {
+             XCTAssertEqual([self networkManagerMock]
+                                .lastPostBody[CR_ApiQueryKeys.regs][CR_ApiQueryKeys.coppa],
+                            @YES);
+             [expectation fulfill];
+           }];
+
   [self cr_waitForExpectations:@[ expectation ]];
 }
 
@@ -255,12 +282,13 @@
   CR_ApiHandler *apiHandler = [self buildApiHandler];
 
   [apiHandler callCdb:@[ testAdUnit ]
-                consent:nil
-                 config:nil
-             deviceInfo:nil
-                context:nil
-          beforeCdbCall:nil
-      completionHandler:nil];
+                     consent:nil
+                      config:nil
+                  deviceInfo:nil
+                     context:nil
+      childDirectedTreatment:nil
+               beforeCdbCall:nil
+           completionHandler:nil];
 }
 
 - (void)testCDBInvokedWhenBidFetchNotInProgress {
@@ -282,12 +310,13 @@
   CR_ApiHandler *apiHandler = [self buildApiHandler];
 
   [apiHandler callCdb:@[ testAdUnit ]
-                consent:nil
-                 config:nil
-             deviceInfo:nil
-                context:self.contextData
-          beforeCdbCall:nil
-      completionHandler:nil];
+                     consent:nil
+                      config:nil
+                  deviceInfo:nil
+                     context:self.contextData
+      childDirectedTreatment:nil
+               beforeCdbCall:nil
+           completionHandler:nil];
   OCMVerifyAllWithDelay(mockBidFetchTracker, 1);
   OCMVerifyAllWithDelay(mockNetworkManager, 1);
 }
@@ -312,12 +341,13 @@
   CR_ApiHandler *apiHandler = [self buildApiHandler];
 
   [apiHandler callCdb:@[ testAdUnit ]
-                consent:nil
-                 config:nil
-             deviceInfo:nil
-                context:self.contextData
-          beforeCdbCall:nil
-      completionHandler:nil];
+                     consent:nil
+                      config:nil
+                  deviceInfo:nil
+                     context:self.contextData
+      childDirectedTreatment:nil
+               beforeCdbCall:nil
+           completionHandler:nil];
   OCMVerifyAllWithDelay(mockBidFetchTracker, 1);
 }
 
@@ -340,12 +370,13 @@
   CR_ApiHandler *apiHandler = [self buildApiHandler];
 
   [apiHandler callCdb:@[ testAdUnit ]
-                consent:nil
-                 config:nil
-             deviceInfo:nil
-                context:self.contextData
-          beforeCdbCall:nil
-      completionHandler:nil];
+                     consent:nil
+                      config:nil
+                  deviceInfo:nil
+                     context:self.contextData
+      childDirectedTreatment:nil
+               beforeCdbCall:nil
+           completionHandler:nil];
   OCMVerifyAllWithDelay(mockBidFetchTracker, 1);
 }
 
@@ -353,15 +384,16 @@
   self.networkManagerMock.respondingToPost = NO;
 
   for (int i = 1; i <= 3; i++) {
-    [self.apiHandler
-                  callCdb:@[ [self buildCacheAdUnit] ]
-                  consent:self.consentMock
-                   config:self.configMock
-               deviceInfo:self.deviceInfoMock
-                  context:self.contextData
-            beforeCdbCall:nil
-        completionHandler:^(CR_CdbRequest *cdbRequest, CR_CdbResponse *cdbResponse, NSError *error){
-        }];
+    [self.apiHandler callCdb:@[ [self buildCacheAdUnit] ]
+                       consent:self.consentMock
+                        config:self.configMock
+                    deviceInfo:self.deviceInfoMock
+                       context:self.contextData
+        childDirectedTreatment:nil
+                 beforeCdbCall:nil
+             completionHandler:^(CR_CdbRequest *cdbRequest, CR_CdbResponse *cdbResponse,
+                                 NSError *error){
+             }];
   }
 
   [self.threadManager waiter_waitIdle];
@@ -682,18 +714,19 @@
       initWithDescription:
           @"Expect that completionHandler is invoked when network error is occurred"];
 
-  [self.apiHandler
-                callCdb:@[ [self buildCacheAdUnit] ]
-                consent:nil
-                 config:nil
-             deviceInfo:nil
-                context:self.contextData
-          beforeCdbCall:nil
-      completionHandler:^(CR_CdbRequest *cdbRequest, CR_CdbResponse *cdbResponse, NSError *error) {
-        XCTAssertNil(cdbResponse);
-        XCTAssertEqual(error, expectedError);
-        [expectation fulfill];
-      }];
+  [self.apiHandler callCdb:@[ [self buildCacheAdUnit] ]
+                     consent:nil
+                      config:nil
+                  deviceInfo:nil
+                     context:self.contextData
+      childDirectedTreatment:nil
+               beforeCdbCall:nil
+           completionHandler:^(CR_CdbRequest *cdbRequest, CR_CdbResponse *cdbResponse,
+                               NSError *error) {
+             XCTAssertNil(cdbResponse);
+             XCTAssertEqual(error, expectedError);
+             [expectation fulfill];
+           }];
 
   [self cr_waitForExpectations:@[ expectation ]];
 }
@@ -791,19 +824,20 @@
 
 - (void)callCdbWithCompletionHandler:(CR_CdbCompletionHandler)completionHandler {
   XCTestExpectation *expectation = [[XCTestExpectation alloc] init];
-  [self.apiHandler
-                callCdb:@[ [self buildCacheAdUnit] ]
-                consent:self.consentMock
-                 config:self.configMock
-             deviceInfo:self.deviceInfoMock
-                context:self.contextData
-          beforeCdbCall:nil
-      completionHandler:^(CR_CdbRequest *cdbRequest, CR_CdbResponse *cdbResponse, NSError *error) {
-        if (completionHandler) {
-          completionHandler(cdbRequest, cdbResponse, error);
-        }
-        [expectation fulfill];
-      }];
+  [self.apiHandler callCdb:@[ [self buildCacheAdUnit] ]
+                     consent:self.consentMock
+                      config:self.configMock
+                  deviceInfo:self.deviceInfoMock
+                     context:self.contextData
+      childDirectedTreatment:nil
+               beforeCdbCall:nil
+           completionHandler:^(CR_CdbRequest *cdbRequest, CR_CdbResponse *cdbResponse,
+                               NSError *error) {
+             if (completionHandler) {
+               completionHandler(cdbRequest, cdbResponse, error);
+             }
+             [expectation fulfill];
+           }];
   [self cr_waitForExpectations:@[ expectation ]];
 }
 


### PR DESCRIPTION
**Changes:**
- Updated CHANGELOG.md.
- Added property `childDirectedTreatment` to Criteo singleton.
- The property `childDirectedTreatment` is actually stored in the `BidManager` class, not `Criteo` class.
- The property `childDirectedTreatment` is then passed from `BidManager` to `CR_ApiHandler` and then to `CR_BidRequestSerializer` and translated into `regs.coppa` in the body request parameters.
- Updated keys from `CR_ApiQueryKeys` to not be optional when used in Swift.
- Added UI toggles for setting the `childDirectedTreatment` property in the `CriteoAdViewer` project application.
- Added and Updated corresponding tests in the modified classes.

| Before | After |
| --- | --- |
![coppa_before](https://user-images.githubusercontent.com/111067505/187639455-493a5123-a3a3-4850-9567-e7278a2f436c.png) | ![coppa_after](https://user-images.githubusercontent.com/111067505/187639531-7148d2b3-6b45-4372-b37e-cd5b67c6bd84.png)
![coppa_ui_before](https://user-images.githubusercontent.com/111067505/187640184-1b7bfe63-a1c6-46b2-8ab1-8a1934ab439e.png) | ![coppa_ui_after](https://user-images.githubusercontent.com/111067505/187640201-1c72c57e-912c-4020-90e7-bd49c69d56df.png)

