### PR TITLE
DPP-4181 [iOS] Update & Fix SwiftLint from CocoaPods

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,9 +1,5 @@
 disabled_rules:
-  # Disable swift-format overlapping rules
-  # We prefer to favor swift-format as swift.org official formatter
-  - opening_brace
-  - trailing_comma
-  # Other rules
-  - identifier_name
-  - type_name
-
+  - line_length # Violated because it can be enabled on-demand from Xcode > Preferences > Text Editing > Wrap lines to editor width
+  - syntactic_sugar # Violated because Dictionary<AnyHashable, String> is easier to read than [AnyHashable:String]
+  - type_name # Violated by class names with underline, like CR_FeedbackStorageTests
+  - vertical_whitespace # Violated by 2-empty line spacing before protocol conformances, MARK, FIXME

--- a/CriteoAdViewer/Sources/AdViewer/AdConfig.swift
+++ b/CriteoAdViewer/Sources/AdViewer/AdConfig.swift
@@ -49,6 +49,6 @@ struct AdConfig {
 func defaultContextData() -> CRContextData {
   CRContextData(dictionary: [
     CRContextDataContentUrl: "http://foo.bar",
-    "data.dummy": 42,
+    "data.dummy": 42
   ])
 }

--- a/CriteoAdViewer/Sources/AdViewer/AdFormat.swift
+++ b/CriteoAdViewer/Sources/AdViewer/AdFormat.swift
@@ -26,13 +26,14 @@ extension AdType: CustomStringConvertible {
 }
 
 enum AdSize: String {
-  case _320x50, _300x250
+  case size320x50
+  case size300x250
 
   func cgSize() -> CGSize {
     switch self {
-    case ._320x50:
+    case .size320x50:
       return CGSize(width: 320, height: 50)
-    case ._300x250:
+    case .size300x250:
       return CGSize(width: 300, height: 250)
     }
   }
@@ -46,8 +47,8 @@ enum AdFormat: Hashable {
   case sized(AdType, AdSize)
   case flexible(AdType)
 
-  static let banner320x50 = AdFormat.sized(.banner, ._320x50)
-  static let banner300x250 = AdFormat.sized(.banner, ._300x250)
+  static let banner320x50 = AdFormat.sized(.banner, .size320x50)
+  static let banner300x250 = AdFormat.sized(.banner, .size300x250)
   static let native = AdFormat.flexible(.native)
   static let interstitial = AdFormat.flexible(.interstitial)
   static let video = AdFormat.flexible(.video)

--- a/CriteoAdViewer/Sources/AdViewer/AdNetwork.swift
+++ b/CriteoAdViewer/Sources/AdViewer/AdNetwork.swift
@@ -91,14 +91,14 @@ private func googleNetwork(_ controller: AdViewController) -> AdNetwork {
       AdFormat.native,
       AdFormat.interstitial,
       AdFormat.video,
-      AdFormat.rewarded,
+      AdFormat.rewarded
     ],
     defaultAdUnits: [
       AdFormat.banner320x50: "/140800857/Endeavour_320x50",
       AdFormat.banner300x250: "/140800857/Endeavour_300x250",
       AdFormat.native: "/140800857/Endeavour_Native",
       AdFormat.interstitial: "/140800857/Endeavour_Interstitial_320x480",
-      AdFormat.video: "/140800857/Endeavour_InterstitialVideo_320x480",
+      AdFormat.video: "/140800857/Endeavour_InterstitialVideo_320x480"
     ],
     specificAdUnits: [
       AdFormat.rewarded: (
@@ -115,12 +115,12 @@ private func standaloneNetwork(_ controller: AdViewController) -> AdNetwork {
     supportedFormats: [
       AdFormat.banner320x50,
       AdFormat.interstitial,
-      AdFormat.native,
+      AdFormat.native
     ],
     defaultAdUnits: [
       AdFormat.banner320x50: "30s6zt3ayypfyemwjvmp",
       AdFormat.interstitial: "6yws53jyfjgoq1ghnuqb",
-      AdFormat.native: "190tsfngohsvfkh3hmkm",
+      AdFormat.native: "190tsfngohsvfkh3hmkm"
     ], adViewBuilder: CriteoAdViewBuilder(controller: controller, type: .standalone))
 }
 
@@ -129,10 +129,10 @@ private func inHouseNetwork(controller: AdViewController) -> AdNetwork {
     name: "InHouse",
     supportedFormats: [
       AdFormat.banner320x50,
-      AdFormat.interstitial,
+      AdFormat.interstitial
     ],
     defaultAdUnits: [
       AdFormat.banner320x50: "30s6zt3ayypfyemwjvmp",
-      AdFormat.interstitial: "6yws53jyfjgoq1ghnuqb",
+      AdFormat.interstitial: "6yws53jyfjgoq1ghnuqb"
     ], adViewBuilder: CriteoAdViewBuilder(controller: controller, type: .inHouse))
 }

--- a/CriteoAdViewer/Sources/AdViewer/AdTableViewController.swift
+++ b/CriteoAdViewer/Sources/AdViewer/AdTableViewController.swift
@@ -31,13 +31,14 @@ class AdTableViewController: UITableViewController {
   private let numberOfCells = 50
 
   private enum CellType: String {
-    case basic, ad
+    case typeBasic
+    case typeAd
   }
 
   override func viewDidLoad() {
     super.viewDidLoad()
-    tableView.register(UITableViewCell.self, forCellReuseIdentifier: CellType.basic.rawValue)
-    tableView.register(UITableViewCell.self, forCellReuseIdentifier: CellType.ad.rawValue)
+    tableView.register(UITableViewCell.self, forCellReuseIdentifier: CellType.typeBasic.rawValue)
+    tableView.register(UITableViewCell.self, forCellReuseIdentifier: CellType.typeAd.rawValue)
   }
 
   // MARK: - Table view data source
@@ -50,17 +51,15 @@ class AdTableViewController: UITableViewController {
     return numberOfCells
   }
 
-  override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat
-  {
+  override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
     return tableView.frame.size.height / CGFloat(adCellIndexPath.row / 2)
   }
 
   override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath)
-    -> UITableViewCell
-  {
+    -> UITableViewCell {
     if indexPath == adCellIndexPath {
       let cell = tableView.dequeueReusableCell(
-        withIdentifier: CellType.ad.rawValue,
+        withIdentifier: CellType.typeAd.rawValue,
         for: indexPath)
       if let adView = adView {
         adView.frame = CGRect(
@@ -74,7 +73,7 @@ class AdTableViewController: UITableViewController {
     }
 
     let cell = tableView.dequeueReusableCell(
-      withIdentifier: CellType.basic.rawValue,
+      withIdentifier: CellType.typeBasic.rawValue,
       for: indexPath)
     cell.textLabel?.text = "Cell \(indexPath.row + 1)"
     return cell

--- a/CriteoAdViewer/Sources/AdViewer/AdViewRow.swift
+++ b/CriteoAdViewer/Sources/AdViewer/AdViewRow.swift
@@ -81,8 +81,7 @@ public final class AdViewRow<ViewType: UIView>: Row<AdViewCell<ViewType, String>
     //  Deal with the case where the caller did not add their custom view to the containerView in a
     //  backwards compatible manner.
     if let view = cell.view,
-      view.superview != cell.contentView
-    {
+      view.superview != cell.contentView {
       view.backgroundColor = AdViewConstants.backgroundColor
       view.removeFromSuperview()
       cell.contentView.addSubview(view)

--- a/CriteoAdViewer/Sources/AdViewer/AdViewerViewController.swift
+++ b/CriteoAdViewer/Sources/AdViewer/AdViewerViewController.swift
@@ -85,11 +85,9 @@ class AdViewerViewController: FormViewController {
   private func advancedSection() -> Section {
     Section("Advanced options") {
       $0.hidden = .function(
-        [Tags.network.rawValue, Tags.type.rawValue],
-        { (form) -> Bool in
+        [Tags.network.rawValue, Tags.type.rawValue], { (form) -> Bool in
           if let typeRow: SegmentedRow<AdType> = self.form.rowBy(tag: Tags.type.rawValue),
-            let type = typeRow.value
-          {
+            let type = typeRow.value {
             return type == .interstitial
           }
           return false
@@ -128,8 +126,7 @@ class AdViewerViewController: FormViewController {
             let typeRow: SegmentedRow<AdType> = self.form.rowBy(tag: Tags.type.rawValue),
             let sizeRow: SegmentedRow<AdSize> = self.form.rowBy(tag: Tags.size.rawValue),
             let network = networkRow.value,
-            let type = typeRow.value
-          {
+            let type = typeRow.value {
             let sizeless = network.sizes(type: type).isEmpty
             if sizeless {
               sizeRow.value = .none
@@ -155,8 +152,7 @@ class AdViewerViewController: FormViewController {
         $0.onChange { (row: SegmentedRow<AdNetwork>) in
           if let network = row.value,
             let typeRow: SegmentedRow<AdType> = self.form.rowBy(tag: Tags.type.rawValue),
-            let sizeRow: SegmentedRow<AdSize> = self.form.rowBy(tag: Tags.size.rawValue)
-          {
+            let sizeRow: SegmentedRow<AdSize> = self.form.rowBy(tag: Tags.size.rawValue) {
             typeRow.options = network.types
             typeRow.value = typeRow.options?.first
             typeRow.reload()
@@ -179,8 +175,7 @@ class AdViewerViewController: FormViewController {
 
   private func buildAdConfig() -> AdConfig? {
     if let network = (self.values[Tags.network.rawValue] as? AdNetwork),
-      let type = (self.values[Tags.type.rawValue] as? AdType)
-    {
+      let type = (self.values[Tags.type.rawValue] as? AdType) {
       let size = (self.values[Tags.size.rawValue] as? AdSize)
       let publisherId =
         (self.values[Tags.publisherId.rawValue] as? String)
@@ -223,8 +218,7 @@ class AdViewerViewController: FormViewController {
   private func displayAd() {
     if let network = (self.values[Tags.network.rawValue] as? AdNetwork),
       let config = adConfig,
-      let criteo = criteo
-    {
+      let criteo = criteo {
       network.adViewBuilder.build(config: config, criteo: criteo) { adView in
         switch adView {
         case .banner(let bannerView):

--- a/CriteoAdViewer/Sources/AdViewer/AdvancedNativeView.swift
+++ b/CriteoAdViewer/Sources/AdViewer/AdvancedNativeView.swift
@@ -47,9 +47,9 @@ class AdvancedNativeView: UIView {
 }
 
 extension AdvancedNativeView: CRNativeLoaderDelegate {
-  public func nativeLoader(_ loader: CRNativeLoader, didReceive ad: CRNativeAd) {
-    delegate?.nativeLoader?(loader, didReceive: ad)
-    adView!.nativeLoader(loader, didReceive: ad)
+  public func nativeLoader(_ loader: CRNativeLoader, didReceive nativeAd: CRNativeAd) {
+    delegate?.nativeLoader?(loader, didReceive: nativeAd)
+    adView!.nativeLoader(loader, didReceive: nativeAd)
   }
 
   public func nativeLoader(_ loader: CRNativeLoader, didFailToReceiveAdWithError error: Error) {

--- a/CriteoAdViewer/Sources/AdViewer/CriteoAdViewBuilder.swift
+++ b/CriteoAdViewer/Sources/AdViewer/CriteoAdViewBuilder.swift
@@ -65,8 +65,7 @@ class CriteoAdViewBuilder: AdViewBuilder {
     return adView
   }
 
-  private func buildInterstitial(_ adUnit: CRInterstitialAdUnit, _ criteo: Criteo) -> CRInterstitial
-  {
+  private func buildInterstitial(_ adUnit: CRInterstitialAdUnit, _ criteo: Criteo) -> CRInterstitial {
     var adView: CRInterstitial
     switch adType {
     case .standalone:

--- a/CriteoAdViewer/Sources/AdViewer/GoogleAdViewBuilder.swift
+++ b/CriteoAdViewer/Sources/AdViewer/GoogleAdViewBuilder.swift
@@ -58,8 +58,8 @@ class GoogleAdViewBuilder: AdViewBuilder {
 
   private func googleAdSize(size: AdSize) -> GADAdSize {
     switch size {
-    case ._320x50: return GADAdSizeBanner
-    case ._300x250: return GADAdSizeMediumRectangle
+    case .size320x50: return GADAdSizeBanner
+    case .size300x250: return GADAdSizeMediumRectangle
     }
   }
 
@@ -74,38 +74,32 @@ class GoogleAdViewBuilder: AdViewBuilder {
     return adView
   }
 
-  private func buildInterstitial(
-    config: AdConfig, criteo: Criteo, completion: @escaping (AdView) -> Void
-  ) {
+  private func buildInterstitial(config: AdConfig, criteo: Criteo, completion: @escaping (AdView) -> Void) {
     let adUnit = config.adUnit
 
     loadAdView(criteo: criteo, adUnit: adUnit) { request in
-      GAMInterstitialAd.load(withAdManagerAdUnitID: config.externalAdUnitId, request: request) {
-        maybeAd, maybeError in
+      GAMInterstitialAd.load(withAdManagerAdUnitID: config.externalAdUnitId, request: request) { maybeAd, maybeError in
         if let error = maybeError {
           print("Failed to load interstitial ad with error: \(error.localizedDescription)")
         }
-        if let ad = maybeAd {
-          ad.fullScreenContentDelegate = self.logger
-          completion(.interstitial(ad))
+        if let maybeAd = maybeAd {
+          maybeAd.fullScreenContentDelegate = self.logger
+          completion(.interstitial(maybeAd))
         }
       }
     }
   }
 
-  private func buildRewarded(
-    config: AdConfig, criteo: Criteo, completion: @escaping (AdView) -> Void
-  ) {
+  private func buildRewarded(config: AdConfig, criteo: Criteo, completion: @escaping (AdView) -> Void) {
     let adUnit = config.adUnit
     loadAdView(criteo: criteo, adUnit: adUnit) { request in
-      GADRewardedAd.load(withAdUnitID: config.externalAdUnitId, request: request) {
-        maybeAd, maybeError in
+      GADRewardedAd.load(withAdUnitID: config.externalAdUnitId, request: request) { maybeAd, maybeError in
         if let error = maybeError {
           print("Failed to load rewarded ad with error: \(error.localizedDescription)")
         }
-        if let ad = maybeAd {
-          ad.fullScreenContentDelegate = self.logger
-          completion(.interstitial(ad))
+        if let maybeAd = maybeAd {
+          maybeAd.fullScreenContentDelegate = self.logger
+          completion(.interstitial(maybeAd))
         }
       }
     }

--- a/CriteoAdViewer/Sources/Logs/LogTableViewController.swift
+++ b/CriteoAdViewer/Sources/Logs/LogTableViewController.swift
@@ -43,8 +43,7 @@ class LogTableViewController: UITableViewController {
   }
 
   override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath)
-    -> UITableViewCell
-  {
+    -> UITableViewCell {
     let cell = tableView.dequeueReusableCell(withIdentifier: "LogEntryCell", for: indexPath)
 
     let logEntry = logManager.logs[indexPath.row]

--- a/CriteoPublisherSdk/CriteoPublisherSdk.xcodeproj/project.pbxproj
+++ b/CriteoPublisherSdk/CriteoPublisherSdk.xcodeproj/project.pbxproj
@@ -1748,6 +1748,7 @@
 				25BD5B532220D16D004DE311 /* Sources */,
 				25BD5B542220D16D004DE311 /* Frameworks */,
 				25BD5B552220D16D004DE311 /* Resources */,
+				E399768528F5A9E000F60EFB /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -1765,6 +1766,7 @@
 				543F6F6522820C1800A5DBE2 /* Sources */,
 				543F6F6622820C1800A5DBE2 /* Frameworks */,
 				543F6F6722820C1800A5DBE2 /* Resources */,
+				E396CC6028F82B3D0039F3B1 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -1783,6 +1785,7 @@
 				E1F2736921B5F08D00A2FBFA /* Sources */,
 				E1F2736A21B5F08D00A2FBFA /* Frameworks */,
 				E1F2736B21B5F08D00A2FBFA /* Resources */,
+				E396CC5F28F82B2D0039F3B1 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -1915,6 +1918,57 @@
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
+		};
+		E396CC5F28F82B2D0039F3B1 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n  swiftlint --config ../.swiftlint.yml\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+		E396CC6028F82B3D0039F3B1 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n  swiftlint --config ../.swiftlint.yml\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+		E399768528F5A9E000F60EFB /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n  swiftlint --config ../.swiftlint.yml\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/CriteoPublisherSdk/Sources/Public/CRNativeLoader.h
+++ b/CriteoPublisherSdk/Sources/Public/CRNativeLoader.h
@@ -79,9 +79,9 @@ NS_ASSUME_NONNULL_BEGIN
  * ad.
  *
  * @param loader Native loader invoking the callback
- * @param ad native ad with the data that may be used to render it
+ * @param nativeAd Native ad with the data that may be used to render it
  */
-- (void)nativeLoader:(CRNativeLoader *)loader didReceiveAd:(CRNativeAd *)ad;
+- (void)nativeLoader:(CRNativeLoader *)loader didReceiveAd:(CRNativeAd *)nativeAd;
 
 /**
  * Callback invoked when the SDK fails to provide a native ad.

--- a/CriteoPublisherSdk/Tests/UnitTests/Feedback/CR_DefaultFileManipulatorTests.swift
+++ b/CriteoPublisherSdk/Tests/UnitTests/Feedback/CR_DefaultFileManipulatorTests.swift
@@ -61,8 +61,8 @@ class CR_DefaultFileManipulatorTests: XCTestCase {
     try self.fileManager.createDirectory(atPath: self.testPath, withIntermediateDirectories: false)
     let bytes = malloc(fileSize)!
     let dummyData = Data(bytes: bytes, count: fileSize)
-    for i in 1...fileCount {
-      let dummyPath = (self.testPath as NSString).appendingPathComponent("dummy\(i)")
+    for count in 1...fileCount {
+      let dummyPath = (self.testPath as NSString).appendingPathComponent("dummy\(count)")
       try NSData(data: dummyData).write(toFile: dummyPath)
     }
   }

--- a/CriteoPublisherSdk/Tests/UnitTests/Feedback/CR_FeedbackFileManagerTests.swift
+++ b/CriteoPublisherSdk/Tests/UnitTests/Feedback/CR_FeedbackFileManagerTests.swift
@@ -36,58 +36,55 @@ class CR_FeedbackFileManagerTests: XCTestCase {
   }
 
   func testReadMissingFile() {
-    let x = self.feedbackFileManager.readFeedback(forFilename: "")
-    XCTAssertNil(x)
+    let feedbackMessage = self.feedbackFileManager.readFeedback(forFilename: "")
+    XCTAssertNil(feedbackMessage)
   }
 
   func testWriteThenRead() {
-    let x = CR_FeedbackMessage()
-    x.cdbCallStartTimestamp = now()
+    let feedbackMessage1 = CR_FeedbackMessage()
+    feedbackMessage1.cdbCallStartTimestamp = now()
 
-    self.feedbackFileManager.writeFeedback(x, forFilename: "")
-    let x1 = self.feedbackFileManager.readFeedback(forFilename: "")
+    self.feedbackFileManager.writeFeedback(feedbackMessage1, forFilename: "")
+    let feedbackMessage2 = self.feedbackFileManager.readFeedback(forFilename: "")
 
-    XCTAssertEqual(x, x1)
+    XCTAssertEqual(feedbackMessage1, feedbackMessage2)
   }
 
   func testOverwriteThenRead() {
-    let x = CR_FeedbackMessage()
+    let feedbackMessage1 = CR_FeedbackMessage()
 
-    x.cdbCallStartTimestamp = now()
-    self.feedbackFileManager.writeFeedback(x, forFilename: "")
+    feedbackMessage1.cdbCallStartTimestamp = now()
+    self.feedbackFileManager.writeFeedback(feedbackMessage1, forFilename: "")
 
-    x.cdbCallStartTimestamp = now()
-    x.cdbCallEndTimestamp = now()
-    self.feedbackFileManager.writeFeedback(x, forFilename: "")
-    let x1 = self.feedbackFileManager.readFeedback(forFilename: "")
+    feedbackMessage1.cdbCallStartTimestamp = now()
+    feedbackMessage1.cdbCallEndTimestamp = now()
+    self.feedbackFileManager.writeFeedback(feedbackMessage1, forFilename: "")
+    let feedbackMessage2 = self.feedbackFileManager.readFeedback(forFilename: "")
 
-    XCTAssertEqual(x, x1)
+    XCTAssertEqual(feedbackMessage1, feedbackMessage2)
   }
 
   func testRemoveMissingFile() {
     self.feedbackFileManager.removeFile(forFilename: "")
-    let x = self.feedbackFileManager.readFeedback(forFilename: "")
-    XCTAssertNil(x)
+    let feedbackMessage = self.feedbackFileManager.readFeedback(forFilename: "")
+    XCTAssertNil(feedbackMessage)
   }
 
   func testRemoveExistingFile() {
     self.feedbackFileManager.writeFeedback(CR_FeedbackMessage(), forFilename: "")
-    let x = self.feedbackFileManager.readFeedback(forFilename: "")
-    XCTAssertNotNil(x)
+    let feedbackMessage1 = self.feedbackFileManager.readFeedback(forFilename: "")
+    XCTAssertNotNil(feedbackMessage1)
 
     self.feedbackFileManager.removeFile(forFilename: "")
-    let x1 = self.feedbackFileManager.readFeedback(forFilename: "")
-    XCTAssertNil(x1)
+    let feedbackMessage2 = self.feedbackFileManager.readFeedback(forFilename: "")
+    XCTAssertNil(feedbackMessage2)
   }
 
   func testInitialisationFailedBecauseNoRootDirectory() {
     let mock = self.fileManipulatingMock!
     mock.rootPaths = []
-    let x =
-      CR_FeedbackFileManager(
-        fileManipulating: mock,
-        activeMetricsMaxFileSize: testsActiveMetricsMaxFileSize) as CR_FeedbackFileManager?
-    XCTAssertNil(x)
+    let feedbackFileManager: CR_FeedbackFileManager? = CR_FeedbackFileManager(fileManipulating: mock, activeMetricsMaxFileSize: testsActiveMetricsMaxFileSize)
+    XCTAssertNil(feedbackFileManager)
   }
 
   func testDirectoryExists_ShouldNotCallCreateDirectory() {
@@ -112,11 +109,9 @@ class CR_FeedbackFileManagerTests: XCTestCase {
     let mock = self.fileManipulatingMock!
     mock.sizeOfDirectory = activeMetricsMaxFileSize
     mock.fileExistsResponse = false
-    self.feedbackFileManager = CR_FeedbackFileManager(
-      fileManipulating: mock,
-      activeMetricsMaxFileSize: activeMetricsMaxFileSize)
-    let x = CR_FeedbackMessage()
-    self.feedbackFileManager.writeFeedback(x, forFilename: "")
+    self.feedbackFileManager = CR_FeedbackFileManager(fileManipulating: mock, activeMetricsMaxFileSize: activeMetricsMaxFileSize)
+    let feedbackMessage = CR_FeedbackMessage()
+    self.feedbackFileManager.writeFeedback(feedbackMessage, forFilename: "")
     XCTAssertNil(mock.message, "Feedback should not be written on maxFileSize bound")
   }
 

--- a/CriteoPublisherSdk/Tests/UnitTests/Feedback/CR_FeedbackMessageTests.swift
+++ b/CriteoPublisherSdk/Tests/UnitTests/Feedback/CR_FeedbackMessageTests.swift
@@ -103,11 +103,9 @@ class CR_FeedbackMessageTests: XCTestCase {
     return result
   }
 
-  private func assertTwoMessagesObjectAndHashEquality(
-    _ a: CR_FeedbackMessage, _ b: CR_FeedbackMessage, file: StaticString = #file, line: UInt = #line
-  ) {
-    XCTAssertEqual(a, b, file: file, line: line)
-    XCTAssertTrue(a.hash == b.hash, file: file, line: line)
+  private func assertTwoMessagesObjectAndHashEquality(_ lhs: CR_FeedbackMessage, _ rhs: CR_FeedbackMessage, file: StaticString = #file, line: UInt = #line) {
+    XCTAssertEqual(lhs, rhs, file: file, line: line)
+    XCTAssertTrue(lhs.hash == rhs.hash, file: file, line: line)
   }
 
   private func assertMessageEqualityAfterEncodingAndDecoding(
@@ -132,6 +130,12 @@ class CR_FeedbackMessageTests: XCTestCase {
 
   private func archiveAndUnarchiveObsoleteWay(message: CR_FeedbackMessage) -> CR_FeedbackMessage {
     let data = NSKeyedArchiver.archivedData(withRootObject: message)
-    return NSKeyedUnarchiver.unarchiveObject(with: data) as! CR_FeedbackMessage
+    do {
+      let feedbackMessage = try XCTUnwrap(NSKeyedUnarchiver.unarchiveObject(with: data) as? CR_FeedbackMessage)
+      return feedbackMessage
+    } catch {
+      XCTFail("Failed to unarchiveObject!")
+    }
+    return CR_FeedbackMessage()
   }
 }

--- a/CriteoPublisherSdk/Tests/UnitTests/Feedback/CR_FeedbackStorageTests.swift
+++ b/CriteoPublisherSdk/Tests/UnitTests/Feedback/CR_FeedbackStorageTests.swift
@@ -46,9 +46,7 @@ class CR_FeedbackStorageTests: XCTestCase {
   func test_initWithActiveMessages_ShouldBeMovedToSendingQueue() throws {
     fileManagingMock = CR_FeedbackFileManagingMock()
     fileManagingMock.allActiveFeedbackFilenamesResult = ["fn1", "fn2"]
-    fileManagingMock.readFeedbackResults = [
-      createMessageWithImpId("1"), createMessageWithImpId("2"),
-    ]
+    fileManagingMock.readFeedbackResults = [createMessageWithImpId("1"), createMessageWithImpId("2")]
     feedbackStorage = CR_FeedbackStorage(fileManager: fileManagingMock, with: queue)
 
     XCTAssertEqual(queue.size(), 2)
@@ -132,9 +130,7 @@ class CR_FeedbackStorageTests: XCTestCase {
   }
 
   func test_updateDifferentObjects() {
-    fileManagingMock.readFeedbackResults = [
-      createMessageWithImpId(impressionId1), createMessageWithImpId(impressionId2),
-    ]
+    fileManagingMock.readFeedbackResults = [createMessageWithImpId(impressionId1), createMessageWithImpId(impressionId2)]
     feedbackStorage.updateMessage(withImpressionId: impressionId1) {
       $0.cdbCallStartTimestamp = self.timestamp1
     }
@@ -142,8 +138,7 @@ class CR_FeedbackStorageTests: XCTestCase {
       $0.cdbCallStartTimestamp = self.timestamp2
     }
     XCTAssertEqual(fileManagingMock.writeFeedbackResults.count, 2)
-    XCTAssertNotEqual(
-      fileManagingMock.writeFeedbackResults[0], fileManagingMock.writeFeedbackResults[1])
+    XCTAssertNotEqual(fileManagingMock.writeFeedbackResults[0], fileManagingMock.writeFeedbackResults[1])
   }
 
   func test_updateMessageToRTS_messageShouldBeMovedToSendingQueue() {
@@ -249,9 +244,7 @@ class CR_FeedbackFileManagingMock: NSObject, CR_FeedbackFileManaging {
 class CR_FeedbackCorruptedStorage: CR_FeedbackStorage {
   var crashedOnce = false
 
-  @objc override func buildSendingQueue(withMaxSize: UInt, fileManager: CR_FeedbackFileManager!)
-    -> CR_CASObjectQueue<CR_FeedbackMessage>
-  {
+  @objc override func buildSendingQueue(withMaxSize: UInt, fileManager: CR_FeedbackFileManager!) -> CR_CASObjectQueue<CR_FeedbackMessage> {
     if !crashedOnce {
       crashedOnce = true
       NSException(name: NSExceptionName.rangeException, reason: "ノಠ益ಠノ彡┻━┻").raise()

--- a/CriteoPublisherSdk/Tests/UnitTests/Logging/CR_RemoteLogStorageTests.swift
+++ b/CriteoPublisherSdk/Tests/UnitTests/Logging/CR_RemoteLogStorageTests.swift
@@ -112,9 +112,7 @@ class FileManipulatorMock: NSObject, CR_FileManipulating {
 class CorruptedRemoteLogStorage: CR_RemoteLogStorage {
   var crashedOnce = false
 
-  @objc override func buildQueue(withAbsolutePath: String, maxFileLength: UInt)
-    -> CR_CASObjectQueue<CR_RemoteLogRecord>
-  {
+  @objc override func buildQueue(withAbsolutePath: String, maxFileLength: UInt) -> CR_CASObjectQueue<CR_RemoteLogRecord> {
     if !crashedOnce {
       crashedOnce = true
       NSException(name: NSExceptionName.rangeException, reason: "ノಠ益ಠノ彡┻━┻").raise()

--- a/CriteoPublisherSdk/Tests/UnitTests/Network/CR_BidRequestSerializerSwiftTests.swift
+++ b/CriteoPublisherSdk/Tests/UnitTests/Network/CR_BidRequestSerializerSwiftTests.swift
@@ -45,10 +45,8 @@ class CR_BidRequestSerializerSwiftTests: XCTestCase {
       internalContextProvider: internalContextProvider)
     request = CR_CdbRequest(
       profileId: testProfileId,
-      adUnits: [
-        CR_CacheAdUnit(adUnitId: "1", width: 1, height: 1),
-        CR_CacheAdUnit(adUnitId: "2", width: 2, height: 2),
-      ])
+      adUnits: [CR_CacheAdUnit(adUnitId: "1", width: 1, height: 1),
+                CR_CacheAdUnit(adUnitId: "2", width: 2, height: 2)])
     config.criteoPublisherId = "Test Published Id"
   }
 
@@ -61,115 +59,72 @@ class CR_BidRequestSerializerSwiftTests: XCTestCase {
 
   func testBodyWithSdkVersion() {
     let body = generateBody()
-
-    let sdkVersion = body[NSString.sdkVersionKey]! as! String
-    XCTAssertEqual(sdkVersion, config.sdkVersion)
+    XCTAssertEqual(body[NSString.sdkVersionKey] as? String, config.sdkVersion)
   }
 
   func testBodyWithProfileId() {
     let body = generateBody()
-
-    let profileId = body[NSString.profileIdKey]! as! NSNumber
-    XCTAssertEqual(profileId, testProfileId)
+    XCTAssertEqual(body[NSString.profileIdKey] as? NSNumber, testProfileId)
   }
 
   func testBodyWithRequestGroupId() {
     let body = generateBody()
-
-    let requestGroupId = body["id"]! as! String
-    XCTAssertEqual(requestGroupId, request.requestGroupId)
+    XCTAssertEqual(body["id"] as? String, request.requestGroupId)
   }
 
   func testBodyWithPublisher() {
-    let expected =
-      [
-        NSString.bundleIdKey: config.appId,
-        NSString.cpIdKey: config.criteoPublisherId!,
-        "ext": [:] as [String: AnyHashable],
-      ] as [String: AnyHashable]
-
+    let expected: NSDictionary = [NSString.bundleIdKey: config.appId, NSString.cpIdKey: config.criteoPublisherId!, "ext": NSDictionary()]
     let body = generateBody()
-
-    let publisher: [String: AnyHashable] = body[NSString.publisherKey]! as! [String: AnyHashable]
-    XCTAssertEqual(publisher, expected)
+    XCTAssertEqual(body[NSString.publisherKey] as? NSDictionary, expected)
   }
 
   // MARK: User in body
 
   func testBodyWithUser() {
     let body = generateBody()
-
-    let user: [String: AnyHashable] = body[NSString.userKey]! as! [String: AnyHashable]
-    XCTAssertEqual(user.count, 8)
-    XCTAssertEqual(user[NSString.userAgentKey], deviceInfo.userAgent)
-    XCTAssertEqual(user[NSString.deviceIdKey], deviceInfo.deviceId)
-    XCTAssertEqual(user[NSString.deviceOsKey], config.deviceOs)
-    XCTAssertEqual(user[NSString.deviceModelKey], config.deviceModel)
-    XCTAssertEqual(user[NSString.deviceIdTypeKey], NSString.deviceIdTypeValue)
-    XCTAssertEqual(user[NSString.uspIabKey], consent.usPrivacyIabConsentString!)
-    XCTAssertEqual(user["ext"], [:] as [String: AnyHashable])
-    XCTAssertEqual(
-      user["skAdNetwork"],
-      [
-        "version": "2.0",
-        "skAdNetworkIds": ["hs6bdukanm.skadnetwork"],
-      ] as [String: AnyHashable])
+    let user: NSDictionary? = body[NSString.userKey] as? NSDictionary
+    XCTAssertEqual(user?.count, 8)
+    XCTAssertEqual(user?[NSString.userAgentKey] as? String, deviceInfo.userAgent)
+    XCTAssertEqual(user?[NSString.deviceIdKey] as? String, deviceInfo.deviceId)
+    XCTAssertEqual(user?[NSString.deviceOsKey] as? String, config.deviceOs)
+    XCTAssertEqual(user?[NSString.deviceModelKey] as? String, config.deviceModel)
+    XCTAssertEqual(user?[NSString.deviceIdTypeKey] as? String, NSString.deviceIdTypeValue)
+    XCTAssertEqual(user?[NSString.uspIabKey] as? String, consent.usPrivacyIabConsentString!)
+    XCTAssertEqual(user?["ext"] as? NSDictionary, NSDictionary())
+    XCTAssertEqual(user?["skAdNetwork"] as? NSDictionary, ["version": "2.0", "skAdNetworkIds": ["hs6bdukanm.skadnetwork"]] as? NSDictionary)
   }
 
   func testBodyWithUsPrivacyConsentString() {
     consent.usPrivacyIabConsentString_mock = "US Privacy String"
-
     let body = generateBody()
-
-    let user: [String: AnyHashable] = body[NSString.userKey]! as! [String: AnyHashable]
-    XCTAssertEqual(user[NSString.uspIabKey]!, "US Privacy String")
+    let user = body[NSString.userKey] as? Dictionary<String, AnyHashable>
+    XCTAssertEqual(user?[NSString.uspIabKey]!, "US Privacy String")
   }
 
   func testBodyWithCriteoPrivacyOpIn() {
     consent.usPrivacyCriteoState = .optIn
-
     let body = generateBody()
-
-    let user: [String: AnyHashable] = body[NSString.userKey]! as! [String: AnyHashable]
-    XCTAssertEqual(user[NSString.uspCriteoOptout]!, false)
+    let user = body[NSString.userKey] as? Dictionary<String, AnyHashable>
+    XCTAssertEqual(user?[NSString.uspCriteoOptout], false)
   }
 
   func testBodyWithCriteoPrivacyOpOut() {
     consent.usPrivacyCriteoState = .optOut
-
     let body = generateBody()
-
-    let user: [String: AnyHashable] = body[NSString.userKey]! as! [String: AnyHashable]
-    XCTAssertEqual(user[NSString.uspCriteoOptout]!, true)
+    let user = body[NSString.userKey] as? Dictionary<String, AnyHashable>
+    XCTAssertEqual(user?[NSString.uspCriteoOptout], true)
   }
 
   func testBodyWithContext() {
-    context = CRContextData(dictionary: [
-      "a.a": "foo",
-      "b": "bar",
-    ])
-
-    let expected =
-      [
-        "a": [
-          "a": "foo"
-        ],
-        "b": "bar",
-      ] as [String: AnyHashable]
-
+    context = CRContextData(dictionary: ["a.a": "foo", "b": "bar"])
+    let expected = ["a": ["a": "foo"], "b": "bar"] as [String: AnyHashable]
     let body = generateBody()
-
-    let publisher = body["publisher"]! as! [String: AnyHashable]
-    XCTAssertEqual(publisher["ext"], expected)
+    let publisher = body["publisher"] as? Dictionary<String, AnyHashable>
+    XCTAssertEqual(publisher?["ext"], expected)
   }
 
-  private func generateBody() -> [String: AnyHashable] {
-    return serializer.body(
-      with: request,
-      consent: consent,
-      config: config,
-      deviceInfo: deviceInfo,
-      context: context) as! [String: AnyHashable]
+  private func generateBody() -> [AnyHashable: Any] {
+    return serializer.body(with: request, consent: consent, config: config, deviceInfo: deviceInfo, context: context)
   }
 }
 

--- a/CriteoPublisherSdk/Tests/UnitTests/Network/CR_FeedbackSerializerTests.swift
+++ b/CriteoPublisherSdk/Tests/UnitTests/Network/CR_FeedbackSerializerTests.swift
@@ -35,14 +35,8 @@ class CR_FeedbackSerializerTests: XCTestCase {
   }
 
   func testMessagesCount() {
-    let messages = [
-      CR_FeedbackMessage(),
-      CR_FeedbackMessage(),
-      CR_FeedbackMessage(),
-    ]
-    let body =
-      self.serializer.postBody(forCsm: messages, config: config, profileId: profileId)
-      as NSDictionary
+    let messages = [CR_FeedbackMessage(), CR_FeedbackMessage(), CR_FeedbackMessage()]
+    let body = self.serializer.postBody(forCsm: messages, config: config, profileId: profileId) as NSDictionary
     let feedbacks = body["feedbacks"] as? NSArray
     XCTAssertEqual(feedbacks?.count, messages.count)
   }
@@ -91,28 +85,33 @@ class CR_FeedbackSerializerTests: XCTestCase {
     message.zoneId = 42
 
     let feedback = serializeSingleMessage(message: message)
-    let slot = (feedback["slots"] as! NSArray)[0] as! NSDictionary
+    let slots = feedback["slots"] as? NSArray
+    let firstSlot = slots?.firstObject as? NSDictionary
 
-    XCTAssertEqual(slot["cachedBidUsed"] as? Bool, true)
-    XCTAssertEqual(slot["impressionId"] as? String, impressionId)
-    XCTAssertEqual(slot["zoneId"] as? Int, 42)
+    XCTAssertEqual(firstSlot?["cachedBidUsed"] as? Bool, true)
+    XCTAssertEqual(firstSlot?["impressionId"] as? String, impressionId)
+    XCTAssertEqual(firstSlot?["zoneId"] as? Int, 42)
   }
 
   func testEmptyMessage_SlotPart() {
     let feedback = serializeSingleMessage(message: CR_FeedbackMessage())
-    let slot = (feedback["slots"] as! NSArray)[0] as! NSDictionary
+    let slots = feedback["slots"] as? NSArray
+    let firstSlot = slots?.firstObject as? NSDictionary
 
-    XCTAssertEqual(slot["cachedBidUsed"] as? Bool, false)
-    XCTAssertNil(slot["impressionId"] as? String)
-    XCTAssertNil(slot["zoneId"] as? Int)
+    XCTAssertEqual(firstSlot?["cachedBidUsed"] as? Bool, false)
+    XCTAssertNil(firstSlot?["impressionId"] as? String)
+    XCTAssertNil(firstSlot?["zoneId"] as? Int)
   }
 
   private func serializeSingleMessage(message: CR_FeedbackMessage) -> NSDictionary {
-    let body =
-      self.serializer.postBody(forCsm: [message], config: config, profileId: profileId)
-      as NSDictionary
-    let feedbacks = body["feedbacks"] as! NSArray
-    let feedback = feedbacks[0] as! NSDictionary
-    return feedback
+    let body = self.serializer.postBody(forCsm: [message], config: config, profileId: profileId)
+    let feedbacks = body["feedbacks"] as? NSArray
+    do {
+      let firstFeedback = try XCTUnwrap(feedbacks?.firstObject as? NSDictionary)
+      return firstFeedback
+    } catch {
+      XCTFail("Failed to extract first feedback!")
+    }
+    return NSDictionary()
   }
 }

--- a/CriteoPublisherSdk/Tests/UnitTests/Network/CR_GdprSerializerTests.swift
+++ b/CriteoPublisherSdk/Tests/UnitTests/Network/CR_GdprSerializerTests.swift
@@ -37,7 +37,7 @@ class CR_GdprSerializerTests: XCTestCase {
     let expected: [String: AnyHashable]? = [
       NSString.gdprVersionKey: 1,
       NSString.gdprConsentDataKey: NSString.gdprConsentStringForTcf1_1,
-      NSString.gdprAppliesKey: true,
+      NSString.gdprAppliesKey: true
     ]
 
     let actual = self.serializer.dictionary(for: self.gdpr)
@@ -51,7 +51,7 @@ class CR_GdprSerializerTests: XCTestCase {
     let expected: [String: AnyHashable]? = [
       NSString.gdprVersionKey: 2,
       NSString.gdprConsentDataKey: NSString.gdprConsentStringForTcf2_0,
-      NSString.gdprAppliesKey: true,
+      NSString.gdprAppliesKey: true
     ]
 
     let actual = self.serializer.dictionary(for: self.gdpr)
@@ -64,7 +64,7 @@ class CR_GdprSerializerTests: XCTestCase {
     self.gdpr.consentStringValue = nil
     let expected: [String: AnyHashable]? = [
       NSString.gdprVersionKey: 2,
-      NSString.gdprAppliesKey: true,
+      NSString.gdprAppliesKey: true
         // No NSString.gdprConsentDataKey
     ]
 
@@ -78,7 +78,7 @@ class CR_GdprSerializerTests: XCTestCase {
     self.gdpr.appliesValue = nil
     let expected: [String: AnyHashable]? = [
       NSString.gdprVersionKey: 2,
-      NSString.gdprConsentDataKey: NSString.gdprConsentStringForTcf2_0,
+      NSString.gdprConsentDataKey: NSString.gdprConsentStringForTcf2_0
       // No NSString.gdprAppliesKey
     ]
 

--- a/Podfile
+++ b/Podfile
@@ -44,7 +44,7 @@ target 'CriteoGoogleAdapterTests' do
 end
 
 # Development tools
-pod 'SwiftLint'
+pod 'SwiftLint', '~> 0.45.0'
 
 post_install do |installer|
   installer.pods_project.targets.each do |target|


### PR DESCRIPTION
**Updated SwiftLint code formatter:**
- Tried updating `SwiftLint CocoaPod` version from `0.45.0` to `0.49.1`, but failed. Leaving it at `0.45.0` for now.
- Added SwiftLint script to each of project’s targets to output the warnings and errors inside Xcode.
- Added `line_length` rule exception because it makes the code more readable at a glance.
- Added `syntactic_sugar` rule exception because it makes the code more readable at a glance.
- Added `vertical_whitespace` rule exception because it makes the code more readable at a glance.
- Removed `force_cast` rule exception and updated the relevant project code.
- Removed `identifier_name ` rule exception and updated the relevant project code.
- Removed `opening_brace` rule exception and updated the relevant project code.
- Removed `trailing_comma` rule exception and updated the relevant project code.
