### PR TITLE
DPP-4182 [iOS] Update deprecated values for GADAdSize from GoogleMobileAds framework

### DIFF
--- a/CriteoAdViewer/Sources/AdViewer/GoogleAdViewBuilder.swift
+++ b/CriteoAdViewer/Sources/AdViewer/GoogleAdViewBuilder.swift
@@ -36,7 +36,7 @@ class GoogleAdViewBuilder: AdViewBuilder {
       completion(
         .banner(buildBanner(config: config, size: googleAdSize(size: size), criteo: criteo)))
     case .flexible(.native):
-      completion(.banner(buildBanner(config: config, size: kGADAdSizeFluid, criteo: criteo)))
+      completion(.banner(buildBanner(config: config, size: GADAdSizeFluid, criteo: criteo)))
     case .flexible(.interstitial), .flexible(.video):
       buildInterstitial(config: config, criteo: criteo, completion: completion)
     case .flexible(.rewarded):
@@ -58,8 +58,8 @@ class GoogleAdViewBuilder: AdViewBuilder {
 
   private func googleAdSize(size: AdSize) -> GADAdSize {
     switch size {
-    case ._320x50: return kGADAdSizeBanner
-    case ._300x250: return kGADAdSizeMediumRectangle
+    case ._320x50: return GADAdSizeBanner
+    case ._300x250: return GADAdSizeMediumRectangle
     }
   }
 

--- a/CriteoGoogleAdapter/Tests/CriteoGoogleAdapterTests/CRBannerCustomEventTests.m
+++ b/CriteoGoogleAdapter/Tests/CriteoGoogleAdapterTests/CRBannerCustomEventTests.m
@@ -78,7 +78,7 @@
   OCMStub([mockCriteo sharedCriteo]).andReturn(mockCriteo);
   OCMStub([mockCriteo registerCriteoPublisherId:@"testCpId" withAdUnits:@[ bannerAdUnit ]]);
 
-  [customEvent requestBannerAd:kGADAdSizeBanner
+  [customEvent requestBannerAd:GADAdSizeBanner
                      parameter:SERVER_PARAMETER
                          label:nil
                        request:[GADCustomEventRequest new]];


### PR DESCRIPTION
The values from `GADAdSize` have been renamed.

- Case `kGADAdSizeBanner` has been renamed to `GADAdSizeBanner`.
- Case `kGADAdSizeMediumRectangle` has been renamed to `GADAdSizeMediumRectangle`.
- Case `kGADAdSizeFluid` has been renamed to `GADAdSizeFluid`.