### PR TITLE
DPP-4182 [iOS] Update deprecated values for GADAdSize from GoogleMobileAds framework

### DIFF
--- a/CriteoGoogleAdapter/Tests/CriteoGoogleAdapterTests/CRBannerCustomEventTests.m
+++ b/CriteoGoogleAdapter/Tests/CriteoGoogleAdapterTests/CRBannerCustomEventTests.m
@@ -99,7 +99,7 @@
   NSString *invalid = @"{\"cpIDD\":\"testCpId\"}";
   customEvent.delegate = mockGADBannerDelegate;
   GADCustomEventRequest *request = [GADCustomEventRequest new];
-  [customEvent requestBannerAd:kGADAdSizeLargeBanner parameter:invalid label:nil request:request];
+  [customEvent requestBannerAd:GADAdSizeLargeBanner parameter:invalid label:nil request:request];
   OCMVerifyAllWithDelay(mockGADBannerDelegate, 1);
 }
 


### PR DESCRIPTION
The values from `GADAdSize` have been renamed.
- Some values have already been changed in [PR 249](https://github.com/criteo/ios-publisher-sdk/pull/249).
- Case `kGADAdSizeLargeBanner` has been renamed to `GADAdSizeLargeBanner`. 