### PR TITLE
[iOS] DPP-3562 Update GAM to version 9 - Part 1 - Some renamings

### DIFF
--- a/CriteoGoogleAdapter/CriteoGoogleAdapter.xcodeproj/project.pbxproj
+++ b/CriteoGoogleAdapter/CriteoGoogleAdapter.xcodeproj/project.pbxproj
@@ -10,16 +10,16 @@
 		174087F82C298114175BCBB5 /* libPods-CriteoGoogleAdapter.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 26D9C65D4FFAA50128EE5DB4 /* libPods-CriteoGoogleAdapter.a */; };
 		463D09452548DAB400086944 /* CriteoGoogleAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 463D09442548DAB400086944 /* CriteoGoogleAdapterTests.swift */; };
 		467CC31B24F818FD000021D1 /* CriteoPublisherSdk.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CF6AE25D24CEB22F00E00CDA /* CriteoPublisherSdk.framework */; };
-		5474B966230F0E3600CBD47E /* CRInterstitialCustomEventTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 54865DA022FA1BA1001F9A67 /* CRInterstitialCustomEventTests.m */; };
-		54FC7DBC22F4147100202164 /* CRInterstitialCustomEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 54FC7DBA22F4147100202164 /* CRInterstitialCustomEvent.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		54FC7DBD22F4147100202164 /* CRInterstitialCustomEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 54FC7DBB22F4147100202164 /* CRInterstitialCustomEvent.m */; };
+		5474B966230F0E3600CBD47E /* CRCustomEventInterstitialTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 54865DA022FA1BA1001F9A67 /* CRCustomEventInterstitialTests.m */; };
+		54FC7DBC22F4147100202164 /* CRCustomEventInterstitial.h in Headers */ = {isa = PBXBuildFile; fileRef = 54FC7DBA22F4147100202164 /* CRCustomEventInterstitial.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		54FC7DBD22F4147100202164 /* CRCustomEventInterstitial.m in Sources */ = {isa = PBXBuildFile; fileRef = 54FC7DBB22F4147100202164 /* CRCustomEventInterstitial.m */; };
 		A36837911ADA01CEDFA729A9 /* libPods-CriteoGoogleAdapterTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BF43AF45DE0BEECB9A9247A6 /* libPods-CriteoGoogleAdapterTests.a */; };
 		C07ABB57E4BA18C3A8A35B47 /* CR_AdMobIntegrationRegistryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C07AB1B8BF317626BD709C00 /* CR_AdMobIntegrationRegistryTests.m */; };
 		CF6AE25E24CEB22F00E00CDA /* CriteoPublisherSdk.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CF6AE25D24CEB22F00E00CDA /* CriteoPublisherSdk.framework */; };
-		DF4356A8230485FA0051AC45 /* CRBannerCustomEventTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DF4356A7230485FA0051AC45 /* CRBannerCustomEventTests.m */; };
+		DF4356A8230485FA0051AC45 /* CRCustomEventBannerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DF4356A7230485FA0051AC45 /* CRCustomEventBannerTests.m */; };
 		DF4356B12304E7B30051AC45 /* CriteoGoogleAdapter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 54FC7DA022F4136100202164 /* CriteoGoogleAdapter.framework */; };
-		DFC3F49B23035A9200318644 /* CRBannerCustomEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = DFC3F49923035A9100318644 /* CRBannerCustomEvent.m */; };
-		DFC3F49C23035A9200318644 /* CRBannerCustomEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = DFC3F49A23035A9100318644 /* CRBannerCustomEvent.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DFC3F49B23035A9200318644 /* CRCustomEventBanner.m in Sources */ = {isa = PBXBuildFile; fileRef = DFC3F49923035A9100318644 /* CRCustomEventBanner.m */; };
+		DFC3F49C23035A9200318644 /* CRCustomEventBanner.h in Headers */ = {isa = PBXBuildFile; fileRef = DFC3F49A23035A9100318644 /* CRCustomEventBanner.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DFC3F4A023035AF800318644 /* CRGoogleMediationParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = DFC3F49D23035AF800318644 /* CRGoogleMediationParameters.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DFC3F4A223035AF800318644 /* CRGoogleMediationParameters.m in Sources */ = {isa = PBXBuildFile; fileRef = DFC3F49F23035AF800318644 /* CRGoogleMediationParameters.m */; };
 		DFC3F4AE230370F700318644 /* CRGoogleMediationParametersTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DFC3F4AD230370F700318644 /* CRGoogleMediationParametersTests.m */; };
@@ -41,20 +41,20 @@
 		17D99DE9CD54BBC14D6A4D45 /* Pods-CriteoGoogleAdapterTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CriteoGoogleAdapterTests.debug.xcconfig"; path = "Target Support Files/Pods-CriteoGoogleAdapterTests/Pods-CriteoGoogleAdapterTests.debug.xcconfig"; sourceTree = "<group>"; };
 		26D9C65D4FFAA50128EE5DB4 /* libPods-CriteoGoogleAdapter.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-CriteoGoogleAdapter.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		463D09442548DAB400086944 /* CriteoGoogleAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CriteoGoogleAdapterTests.swift; sourceTree = "<group>"; };
-		54865DA022FA1BA1001F9A67 /* CRInterstitialCustomEventTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CRInterstitialCustomEventTests.m; sourceTree = "<group>"; };
+		54865DA022FA1BA1001F9A67 /* CRCustomEventInterstitialTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CRCustomEventInterstitialTests.m; sourceTree = "<group>"; };
 		54FC7DA022F4136100202164 /* CriteoGoogleAdapter.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CriteoGoogleAdapter.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		54FC7DA422F4136100202164 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		54FC7DA922F4136100202164 /* CriteoGoogleAdapterTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CriteoGoogleAdapterTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		54FC7DB022F4136100202164 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		54FC7DBA22F4147100202164 /* CRInterstitialCustomEvent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CRInterstitialCustomEvent.h; sourceTree = "<group>"; };
-		54FC7DBB22F4147100202164 /* CRInterstitialCustomEvent.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CRInterstitialCustomEvent.m; sourceTree = "<group>"; };
+		54FC7DBA22F4147100202164 /* CRCustomEventInterstitial.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CRCustomEventInterstitial.h; sourceTree = "<group>"; };
+		54FC7DBB22F4147100202164 /* CRCustomEventInterstitial.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CRCustomEventInterstitial.m; sourceTree = "<group>"; };
 		BF43AF45DE0BEECB9A9247A6 /* libPods-CriteoGoogleAdapterTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-CriteoGoogleAdapterTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C07AB1B8BF317626BD709C00 /* CR_AdMobIntegrationRegistryTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CR_AdMobIntegrationRegistryTests.m; sourceTree = "<group>"; };
 		CF6AE25D24CEB22F00E00CDA /* CriteoPublisherSdk.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = CriteoPublisherSdk.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D6D6F0BAD5AE72930DD2A529 /* Pods-CriteoGoogleAdapterTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CriteoGoogleAdapterTests.release.xcconfig"; path = "Target Support Files/Pods-CriteoGoogleAdapterTests/Pods-CriteoGoogleAdapterTests.release.xcconfig"; sourceTree = "<group>"; };
-		DF4356A7230485FA0051AC45 /* CRBannerCustomEventTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CRBannerCustomEventTests.m; sourceTree = "<group>"; };
-		DFC3F49923035A9100318644 /* CRBannerCustomEvent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CRBannerCustomEvent.m; sourceTree = "<group>"; };
-		DFC3F49A23035A9100318644 /* CRBannerCustomEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CRBannerCustomEvent.h; sourceTree = "<group>"; };
+		DF4356A7230485FA0051AC45 /* CRCustomEventBannerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CRCustomEventBannerTests.m; sourceTree = "<group>"; };
+		DFC3F49923035A9100318644 /* CRCustomEventBanner.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CRCustomEventBanner.m; sourceTree = "<group>"; };
+		DFC3F49A23035A9100318644 /* CRCustomEventBanner.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CRCustomEventBanner.h; sourceTree = "<group>"; };
 		DFC3F49D23035AF800318644 /* CRGoogleMediationParameters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CRGoogleMediationParameters.h; sourceTree = "<group>"; };
 		DFC3F49F23035AF800318644 /* CRGoogleMediationParameters.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CRGoogleMediationParameters.m; sourceTree = "<group>"; };
 		DFC3F4AD230370F700318644 /* CRGoogleMediationParametersTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CRGoogleMediationParametersTests.m; sourceTree = "<group>"; };
@@ -130,10 +130,10 @@
 			children = (
 				DFC3F49D23035AF800318644 /* CRGoogleMediationParameters.h */,
 				DFC3F49F23035AF800318644 /* CRGoogleMediationParameters.m */,
-				DFC3F49A23035A9100318644 /* CRBannerCustomEvent.h */,
-				DFC3F49923035A9100318644 /* CRBannerCustomEvent.m */,
-				54FC7DBA22F4147100202164 /* CRInterstitialCustomEvent.h */,
-				54FC7DBB22F4147100202164 /* CRInterstitialCustomEvent.m */,
+				DFC3F49A23035A9100318644 /* CRCustomEventBanner.h */,
+				DFC3F49923035A9100318644 /* CRCustomEventBanner.m */,
+				54FC7DBA22F4147100202164 /* CRCustomEventInterstitial.h */,
+				54FC7DBB22F4147100202164 /* CRCustomEventInterstitial.m */,
 				54FC7DA422F4136100202164 /* Info.plist */,
 			);
 			name = CriteoGoogleAdapter;
@@ -146,8 +146,8 @@
 				54FC7DB022F4136100202164 /* Info.plist */,
 				463D09442548DAB400086944 /* CriteoGoogleAdapterTests.swift */,
 				DFC3F4AD230370F700318644 /* CRGoogleMediationParametersTests.m */,
-				DF4356A7230485FA0051AC45 /* CRBannerCustomEventTests.m */,
-				54865DA022FA1BA1001F9A67 /* CRInterstitialCustomEventTests.m */,
+				DF4356A7230485FA0051AC45 /* CRCustomEventBannerTests.m */,
+				54865DA022FA1BA1001F9A67 /* CRCustomEventInterstitialTests.m */,
 				C07AB1B8BF317626BD709C00 /* CR_AdMobIntegrationRegistryTests.m */,
 			);
 			name = CriteoGoogleAdapterTests;
@@ -161,8 +161,8 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				54FC7DBC22F4147100202164 /* CRInterstitialCustomEvent.h in Headers */,
-				DFC3F49C23035A9200318644 /* CRBannerCustomEvent.h in Headers */,
+				54FC7DBC22F4147100202164 /* CRCustomEventInterstitial.h in Headers */,
+				DFC3F49C23035A9200318644 /* CRCustomEventBanner.h in Headers */,
 				DFC3F4A023035AF800318644 /* CRGoogleMediationParameters.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -322,8 +322,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DFC3F49B23035A9200318644 /* CRBannerCustomEvent.m in Sources */,
-				54FC7DBD22F4147100202164 /* CRInterstitialCustomEvent.m in Sources */,
+				DFC3F49B23035A9200318644 /* CRCustomEventBanner.m in Sources */,
+				54FC7DBD22F4147100202164 /* CRCustomEventInterstitial.m in Sources */,
 				DFC3F4A223035AF800318644 /* CRGoogleMediationParameters.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -332,8 +332,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5474B966230F0E3600CBD47E /* CRInterstitialCustomEventTests.m in Sources */,
-				DF4356A8230485FA0051AC45 /* CRBannerCustomEventTests.m in Sources */,
+				5474B966230F0E3600CBD47E /* CRCustomEventInterstitialTests.m in Sources */,
+				DF4356A8230485FA0051AC45 /* CRCustomEventBannerTests.m in Sources */,
 				463D09452548DAB400086944 /* CriteoGoogleAdapterTests.swift in Sources */,
 				DFC3F4AE230370F700318644 /* CRGoogleMediationParametersTests.m in Sources */,
 				C07ABB57E4BA18C3A8A35B47 /* CR_AdMobIntegrationRegistryTests.m in Sources */,

--- a/CriteoGoogleAdapter/Sources/CriteoGoogleAdapter/CRCustomEventBanner.h
+++ b/CriteoGoogleAdapter/Sources/CriteoGoogleAdapter/CRCustomEventBanner.h
@@ -1,5 +1,5 @@
 //
-//  CRBannerCustomEvent.h
+//  CRCustomEventBanner.h
 //  CriteoGoogleAdapter
 //
 //  Copyright © 2018-2020 Criteo. All rights reserved.
@@ -14,8 +14,8 @@
 //  express or implied. See the License for the specific language governing permissions and
 //  limitations under the License.
 
-#ifndef CRBannerCustomEvent_h
-#define CRBannerCustomEvent_h
+#ifndef CRCustomEventBanner_h
+#define CRCustomEventBanner_h
 
 #import <Foundation/Foundation.h>
 @import GoogleMobileAds;
@@ -23,9 +23,9 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface CRBannerCustomEvent : NSObject <GADCustomEventBanner, CRBannerViewDelegate>
+@interface CRCustomEventBanner : NSObject <GADCustomEventBanner, CRBannerViewDelegate>
 @end
 
 NS_ASSUME_NONNULL_END
 
-#endif /* CRBannerCustomEvent_h */
+#endif /* CRCustomEventBanner_h */

--- a/CriteoGoogleAdapter/Sources/CriteoGoogleAdapter/CRCustomEventBanner.m
+++ b/CriteoGoogleAdapter/Sources/CriteoGoogleAdapter/CRCustomEventBanner.m
@@ -1,5 +1,5 @@
 //
-//  CRBannerCustomEvent.m
+//  CRCustomEventBanner.m
 //  CriteoGoogleAdapter
 //
 //  Copyright © 2018-2020 Criteo. All rights reserved.
@@ -14,17 +14,17 @@
 //  express or implied. See the License for the specific language governing permissions and
 //  limitations under the License.
 
-#import "CRBannerCustomEvent.h"
+#import "CRCustomEventBanner.h"
 #import "CRGoogleMediationParameters.h"
 
 // Private property
-@interface CRBannerCustomEvent ()
+@interface CRCustomEventBanner ()
 
 @property(nonatomic, strong) CRBannerView *bannerView;
 
 @end
 
-@implementation CRBannerCustomEvent
+@implementation CRCustomEventBanner
 
 @synthesize delegate;
 
@@ -39,7 +39,7 @@
       [CRGoogleMediationParameters parametersFromJSONString:serverParameter error:&error];
   if (params == nil) {
     if ([self.delegate respondsToSelector:@selector(customEventBanner:didFailAd:)]) {
-      __block CRBannerCustomEvent *blocksafeSelf = self;
+      __block CRCustomEventBanner *blocksafeSelf = self;
       dispatch_async(dispatch_get_main_queue(), ^{
         [blocksafeSelf.delegate customEventBanner:blocksafeSelf didFailAd:error];
       });

--- a/CriteoGoogleAdapter/Sources/CriteoGoogleAdapter/CRCustomEventInterstitial.h
+++ b/CriteoGoogleAdapter/Sources/CriteoGoogleAdapter/CRCustomEventInterstitial.h
@@ -1,8 +1,8 @@
 //
-//  CRCustomBannerEvent.h
-//  CriteoMoPubAdapter
+//  CRCustomEventInterstitial.h
+//  CriteoGoogleAdapter
 //
-//  Copyright © 2018-2020 Criteo. All rights reserved.
+// Copyright © 2018-2020 Criteo. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,25 +16,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if __has_include(<MoPub/MoPub.h>)
-#import <MoPub/MoPub.h>
-#elif __has_include(<MoPubSDK/MoPub.h>)
-#import <MoPubSDK/MoPub.h>
-#elif __has_include(<MoPubSDKFramework/MoPub.h>)
-#import <MoPubSDKFramework/MoPub.h>
-#else
-#import "MoPub.h"
-#import "MPInlineAdAdapter.h"
-#endif
-
 #import <Foundation/Foundation.h>
 #import <CriteoPublisherSdk/CriteoPublisherSdk.h>
-#import "CRCriteoAdapterConfiguration.h"
+@import GoogleMobileAds;
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface CRBannerCustomEvent
-    : MPInlineAdAdapter <CRBannerViewDelegate, MPThirdPartyInlineAdAdapter>
+@interface CRCustomEventInterstitial : NSObject <GADCustomEventInterstitial, CRInterstitialDelegate>
+@property(nonatomic, weak, nullable) id<GADCustomEventInterstitialDelegate> delegate;
+
+- (void)requestInterstitialAdWithParameter:(nullable NSString *)serverParameter
+                                     label:(nullable NSString *)serverLabel
+                                   request:(nonnull GADCustomEventRequest *)request;
+
+- (void)presentFromRootViewController:(nonnull UIViewController *)rootViewController;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/CriteoGoogleAdapter/Sources/CriteoGoogleAdapter/CRCustomEventInterstitial.m
+++ b/CriteoGoogleAdapter/Sources/CriteoGoogleAdapter/CRCustomEventInterstitial.m
@@ -1,5 +1,5 @@
 //
-//  CRInterstitialCustomEvent.m
+//  CRCustomEventInterstitial.m
 //  CriteoGoogleAdapter
 //
 // Copyright © 2018-2020 Criteo. All rights reserved.
@@ -16,17 +16,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "CRInterstitialCustomEvent.h"
+#import "CRCustomEventInterstitial.h"
 #import "CRGoogleMediationParameters.h"
 
 // Private property
-@interface CRInterstitialCustomEvent ()
+@interface CRCustomEventInterstitial ()
 
 @property(nonatomic, strong) CRInterstitial *interstitial;
 
 @end
 
-@implementation CRInterstitialCustomEvent
+@implementation CRCustomEventInterstitial
 
 - (void)presentFromRootViewController:(nonnull UIViewController *)rootViewController {
   [self.interstitial presentFromRootViewController:rootViewController];

--- a/CriteoGoogleAdapter/Tests/CriteoGoogleAdapterTests/CRCustomEventBannerTests.m
+++ b/CriteoGoogleAdapter/Tests/CriteoGoogleAdapterTests/CRCustomEventBannerTests.m
@@ -1,5 +1,5 @@
 //
-//  CRBannerCustomEventTests.m
+//  CRCustomEventBannerTests.m
 //  CriteoGoogleAdapterTests
 //
 //  Copyright © 2018-2020 Criteo. All rights reserved.
@@ -15,28 +15,28 @@
 //  limitations under the License.
 
 #import <XCTest/XCTest.h>
-#import "CRBannerCustomEvent.h"
+#import "CRCustomEventBanner.h"
 #import <OCMock.h>
 
-@interface CRBannerCustomEventTests : XCTestCase
+@interface CRCustomEventBannerTests : XCTestCase
 
 @end
 
 // Private property
-@interface CRBannerCustomEvent ()
+@interface CRCustomEventBanner ()
 
 @property(nonatomic, strong) CRBannerView *bannerView;
 
 @end
 
 // Test-only initializer
-@interface CRBannerCustomEvent (Test)
+@interface CRCustomEventBanner (Test)
 
 - (instancetype)initWithBannerView:(CRBannerView *)bannerView;
 
 @end
 
-@implementation CRBannerCustomEvent (Test)
+@implementation CRCustomEventBanner (Test)
 
 - (instancetype)initWithBannerView:(CRBannerView *)bannerView {
   if (self = [super init]) {
@@ -62,14 +62,14 @@
 
 #define SERVER_PARAMETER @"{\"cpId\":\"testCpId\",\"adUnitId\":\"testAdUnitId\"}"
 
-@implementation CRBannerCustomEventTests
+@implementation CRCustomEventBannerTests
 
 - (void)testRequestBannerAdSuccess {
   CRBannerView *mockCRBannerView = OCMStrictClassMock([CRBannerView class]);
   CRBannerAdUnit *bannerAdUnit = [[CRBannerAdUnit alloc] initWithAdUnitId:@"testAdUnitId"
                                                                      size:CGSizeMake(320, 50)];
-  CRBannerCustomEvent *customEvent =
-      [[CRBannerCustomEvent alloc] initWithBannerView:mockCRBannerView];
+  CRCustomEventBanner *customEvent =
+      [[CRCustomEventBanner alloc] initWithBannerView:mockCRBannerView];
 
   OCMStub([mockCRBannerView loadAd]);
   OCMStub([mockCRBannerView setDelegate:customEvent]);
@@ -89,7 +89,7 @@
 }
 
 - (void)testRequestBannerAdFail {
-  CRBannerCustomEvent *customEvent = [CRBannerCustomEvent new];
+  CRCustomEventBanner *customEvent = [CRCustomEventBanner new];
   id mockGADBannerDelegate = OCMStrictProtocolMock(@protocol(GADCustomEventBannerDelegate));
   OCMExpect([mockGADBannerDelegate
       customEventBanner:customEvent
@@ -106,7 +106,7 @@
 #pragma mark CRBannerViewDelegate tests
 
 - (void)testDidReceiveAdDelegate {
-  CRBannerCustomEvent *customEvent = [CRBannerCustomEvent new];
+  CRCustomEventBanner *customEvent = [CRCustomEventBanner new];
   CRBannerView *bannerView = [CRBannerView new];
   id mockGADBannerDelegate = OCMStrictProtocolMock(@protocol(GADCustomEventBannerDelegate));
   OCMExpect([mockGADBannerDelegate customEventBanner:customEvent didReceiveAd:bannerView]);
@@ -116,7 +116,7 @@
 }
 
 - (void)testDidFailToReceiveAdDelegate {
-  CRBannerCustomEvent *customEvent = [CRBannerCustomEvent new];
+  CRCustomEventBanner *customEvent = [CRCustomEventBanner new];
   id mockGADBannerDelegate = OCMStrictProtocolMock(@protocol(GADCustomEventBannerDelegate));
   NSError *criteoError =
       [NSError errorWithDomain:@"test domain"
@@ -135,7 +135,7 @@
 }
 
 - (void)testWillLeaveApplicationDelegate {
-  CRBannerCustomEvent *customEvent = [CRBannerCustomEvent new];
+  CRCustomEventBanner *customEvent = [CRCustomEventBanner new];
   id mockGADBannerDelegate = OCMStrictProtocolMock(@protocol(GADCustomEventBannerDelegate));
   OCMExpect([mockGADBannerDelegate customEventBannerWasClicked:customEvent]);
   OCMExpect([mockGADBannerDelegate customEventBannerWillLeaveApplication:customEvent]);
@@ -145,7 +145,7 @@
 }
 
 - (void)testWillLeaveApplicationDelegateDeprecated {
-  CRBannerCustomEvent *customEvent = [CRBannerCustomEvent new];
+  CRCustomEventBanner *customEvent = [CRCustomEventBanner new];
   id mockGADBannerDelegate =
       OCMStrictProtocolMock(@protocol(GADCustomEventBannerDelegateDeprecated));
   CRBannerView *bannerView = [CRBannerView new];

--- a/CriteoGoogleAdapter/Tests/CriteoGoogleAdapterTests/CRCustomEventInterstitialTests.m
+++ b/CriteoGoogleAdapter/Tests/CriteoGoogleAdapterTests/CRCustomEventInterstitialTests.m
@@ -1,5 +1,5 @@
 //
-//  CRInterstitialCustomEventTests.m
+//  CRCustomEventInterstitialTests.m
 //  CriteoGoogleAdapterTests
 //
 // Copyright © 2018-2020 Criteo. All rights reserved.
@@ -18,28 +18,28 @@
 
 #import <XCTest/XCTest.h>
 #import <OCMock.h>
-#import "CRInterstitialCustomEvent.h"
+#import "CRCustomEventInterstitial.h"
 
-@interface CRInterstitialCustomEventTests : XCTestCase
+@interface CRCustomEventInterstitialTests : XCTestCase
 
 @end
 
-// Private property (duplicates code in CRInterstitialCustomEvent.m so that we can use it in
+// Private property (duplicates code in CRCustomEventInterstitial.m so that we can use it in
 // testing)
-@interface CRInterstitialCustomEvent ()
+@interface CRCustomEventInterstitial ()
 
 @property(nonatomic, strong) CRInterstitial *interstitial;
 
 @end
 
 // Test-only initializer
-@interface CRInterstitialCustomEvent (Test)
+@interface CRCustomEventInterstitial (Test)
 
 - (instancetype)initWithInterstitial:(CRInterstitial *)interstitial;
 
 @end
 
-@implementation CRInterstitialCustomEvent (Test)
+@implementation CRCustomEventInterstitial (Test)
 
 - (instancetype)initWithInterstitial:(CRInterstitial *)interstitial {
   if (self = [super init]) {
@@ -52,10 +52,10 @@
 
 #define SERVER_PARAMETER @"{\"cpId\":\"testCpId\",\"adUnitId\":\"testAdUnitId\"}"
 
-@implementation CRInterstitialCustomEventTests
+@implementation CRCustomEventInterstitialTests
 
 - (void)testCustomEventDelegateFailWhenParametersIsNil {
-  CRInterstitialCustomEvent *customEvent = [CRInterstitialCustomEvent new];
+  CRCustomEventInterstitial *customEvent = [CRCustomEventInterstitial new];
   id mockGADInterstitialDelegate =
       OCMStrictProtocolMock(@protocol(GADCustomEventInterstitialDelegate));
   OCMExpect([mockGADInterstitialDelegate
@@ -75,8 +75,8 @@
   CRInterstitial *mockCRInterstitial = OCMStrictClassMock([CRInterstitial class]);
   CRInterstitialAdUnit *interstitialAdUnit =
       [[CRInterstitialAdUnit alloc] initWithAdUnitId:@"testAdUnitId"];
-  CRInterstitialCustomEvent *customEvent =
-      [[CRInterstitialCustomEvent alloc] initWithInterstitial:mockCRInterstitial];
+  CRCustomEventInterstitial *customEvent =
+      [[CRCustomEventInterstitial alloc] initWithInterstitial:mockCRInterstitial];
 
   OCMStub([mockCRInterstitial loadAd]);
   OCMStub([mockCRInterstitial setDelegate:customEvent]);
@@ -101,7 +101,7 @@
 #pragma mark CRInterstitial Delegate tests
 
 - (void)testDidFailToReceiveAdDelegate {
-  CRInterstitialCustomEvent *customEvent = [CRInterstitialCustomEvent new];
+  CRCustomEventInterstitial *customEvent = [CRCustomEventInterstitial new];
   id mockGADInterstitialDelegate =
       OCMStrictProtocolMock(@protocol(GADCustomEventInterstitialDelegate));
   NSError *CriteoError =
@@ -121,7 +121,7 @@
 }
 
 - (void)testWillAppearDelegate {
-  CRInterstitialCustomEvent *customEvent = [CRInterstitialCustomEvent new];
+  CRCustomEventInterstitial *customEvent = [CRCustomEventInterstitial new];
   id mockGADInterstitialDelegate =
       OCMStrictProtocolMock(@protocol(GADCustomEventInterstitialDelegate));
   OCMExpect([mockGADInterstitialDelegate customEventInterstitialWillPresent:customEvent]);
@@ -132,7 +132,7 @@
 }
 
 - (void)testWillDisappearDelegate {
-  CRInterstitialCustomEvent *customEvent = [CRInterstitialCustomEvent new];
+  CRCustomEventInterstitial *customEvent = [CRCustomEventInterstitial new];
   id mockGADInterstitialDelegate =
       OCMStrictProtocolMock(@protocol(GADCustomEventInterstitialDelegate));
   OCMExpect([mockGADInterstitialDelegate customEventInterstitialWillDismiss:customEvent]);
@@ -143,7 +143,7 @@
 }
 
 - (void)testDidDisappearDelegate {
-  CRInterstitialCustomEvent *customEvent = [CRInterstitialCustomEvent new];
+  CRCustomEventInterstitial *customEvent = [CRCustomEventInterstitial new];
   id mockGADInterstitialDelegate =
       OCMStrictProtocolMock(@protocol(GADCustomEventInterstitialDelegate));
   OCMExpect([mockGADInterstitialDelegate customEventInterstitialDidDismiss:customEvent]);
@@ -154,7 +154,7 @@
 }
 
 - (void)testWillLeaveApplicationDelegate {
-  CRInterstitialCustomEvent *customEvent = [CRInterstitialCustomEvent new];
+  CRCustomEventInterstitial *customEvent = [CRCustomEventInterstitial new];
   id mockGADInterstitialDelegate =
       OCMStrictProtocolMock(@protocol(GADCustomEventInterstitialDelegate));
   OCMExpect([mockGADInterstitialDelegate customEventInterstitialWasClicked:customEvent]);
@@ -166,7 +166,7 @@
 }
 
 - (void)testInterstitialDidReceiveAdDelegate {
-  CRInterstitialCustomEvent *customEvent = [CRInterstitialCustomEvent new];
+  CRCustomEventInterstitial *customEvent = [CRCustomEventInterstitial new];
   id mockGADInterstitialDelegate =
       OCMStrictProtocolMock(@protocol(GADCustomEventInterstitialDelegate));
   OCMExpect([mockGADInterstitialDelegate customEventInterstitialDidReceiveAd:customEvent]);
@@ -177,7 +177,7 @@
 }
 
 - (void)testInterstitialDidFailToReceiveAdContentWithErrorDelegate {
-  CRInterstitialCustomEvent *customEvent = [CRInterstitialCustomEvent new];
+  CRCustomEventInterstitial *customEvent = [CRCustomEventInterstitial new];
   id mockGADInterstitialDelegate =
       OCMStrictProtocolMock(@protocol(GADCustomEventInterstitialDelegate));
   OCMExpect([mockGADInterstitialDelegate customEventInterstitial:customEvent

--- a/CriteoMoPubAdapter/Sources/CriteoMoPubAdapter/CRCustomEventBanner.h
+++ b/CriteoMoPubAdapter/Sources/CriteoMoPubAdapter/CRCustomEventBanner.h
@@ -1,8 +1,8 @@
 //
-//  CRInterstitialCustomEvent.h
-//  CriteoGoogleAdapter
+//  CRCustomBannerEvent.h
+//  CriteoMoPubAdapter
 //
-// Copyright © 2018-2020 Criteo. All rights reserved.
+//  Copyright © 2018-2020 Criteo. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,21 +16,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if __has_include(<MoPub/MoPub.h>)
+#import <MoPub/MoPub.h>
+#elif __has_include(<MoPubSDK/MoPub.h>)
+#import <MoPubSDK/MoPub.h>
+#elif __has_include(<MoPubSDKFramework/MoPub.h>)
+#import <MoPubSDKFramework/MoPub.h>
+#else
+#import "MoPub.h"
+#import "MPInlineAdAdapter.h"
+#endif
+
 #import <Foundation/Foundation.h>
 #import <CriteoPublisherSdk/CriteoPublisherSdk.h>
-@import GoogleMobileAds;
+#import "CRCriteoAdapterConfiguration.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface CRInterstitialCustomEvent : NSObject <GADCustomEventInterstitial, CRInterstitialDelegate>
-@property(nonatomic, weak, nullable) id<GADCustomEventInterstitialDelegate> delegate;
-
-- (void)requestInterstitialAdWithParameter:(nullable NSString *)serverParameter
-                                     label:(nullable NSString *)serverLabel
-                                   request:(nonnull GADCustomEventRequest *)request;
-
-- (void)presentFromRootViewController:(nonnull UIViewController *)rootViewController;
-
+@interface CRCustomEventBanner
+    : MPInlineAdAdapter <CRBannerViewDelegate, MPThirdPartyInlineAdAdapter>
 @end
 
 NS_ASSUME_NONNULL_END

--- a/CriteoMoPubAdapter/Sources/CriteoMoPubAdapter/CRCustomEventBanner.m
+++ b/CriteoMoPubAdapter/Sources/CriteoMoPubAdapter/CRCustomEventBanner.m
@@ -16,18 +16,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "CRBannerCustomEvent.h"
+#import "CRCustomEventBanner.h"
 #import "CRCustomEventHelper.h"
 #import "NSString+MPConsentStatus.h"
 
 // Private properties
-@interface CRBannerCustomEvent ()
+@interface CRCustomEventBanner ()
 
 @property(nonatomic, strong) CRBannerView *bannerView;
 
 @end
 
-@implementation CRBannerCustomEvent
+@implementation CRCustomEventBanner
 
 @synthesize delegate;
 @synthesize localExtras;

--- a/CriteoMoPubAdapter/Sources/CriteoMoPubAdapter/CRCustomEventInterstitial.h
+++ b/CriteoMoPubAdapter/Sources/CriteoMoPubAdapter/CRCustomEventInterstitial.h
@@ -32,7 +32,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface CRInterstitialCustomEvent
+@interface CRCustomEventInterstitial
     : MPFullscreenAdAdapter <CRInterstitialDelegate, MPThirdPartyFullscreenAdAdapter>
 @end
 

--- a/CriteoMoPubAdapter/Sources/CriteoMoPubAdapter/CRCustomEventInterstitial.m
+++ b/CriteoMoPubAdapter/Sources/CriteoMoPubAdapter/CRCustomEventInterstitial.m
@@ -1,5 +1,5 @@
 //
-//  CRInterstitialCustomEvent.m
+//  CRCustomEventInterstitial.m
 //  CriteoMoPubAdapter
 //
 //  Copyright © 2018-2020 Criteo. All rights reserved.
@@ -17,17 +17,17 @@
 // limitations under the License.
 
 #import <Foundation/Foundation.h>
-#import "CRInterstitialCustomEvent.h"
+#import "CRCustomEventInterstitial.h"
 #import "CRCustomEventHelper.h"
 #import "NSString+MPConsentStatus.h"
 
-@interface CRInterstitialCustomEvent ()
+@interface CRCustomEventInterstitial ()
 
 @property(nonatomic, strong) CRInterstitial *interstitial;
 
 @end
 
-@implementation CRInterstitialCustomEvent
+@implementation CRCustomEventInterstitial
 
 @synthesize delegate;
 @synthesize localExtras;

--- a/CriteoMoPubAdapter/Tests/CriteoMoPubAdapterTests/CRCustomEventBannerTests.m
+++ b/CriteoMoPubAdapter/Tests/CriteoMoPubAdapterTests/CRCustomEventBannerTests.m
@@ -1,5 +1,5 @@
 //
-//  CRBannerCustomEventTests.m
+//  CRCustomEventBannerTests.m
 //  CriteoMoPubAdapterTests
 //
 //  Copyright © 2018-2020 Criteo. All rights reserved.
@@ -17,17 +17,17 @@
 // limitations under the License.
 
 #import <XCTest/XCTest.h>
-#import "CRBannerCustomEvent.h"
+#import "CRCustomEventBanner.h"
 #import <OCMock.h>
 #import <CriteoPublisherSdk/CriteoPublisherSdk.h>
 
-@interface CRBannerCustomEvent ()
+@interface CRCustomEventBanner ()
 
 @property(nonatomic, strong) CRBannerView *bannerView;
 
 @end
 
-@interface CRBannerCustomEvent (Test)
+@interface CRCustomEventBanner (Test)
 
 - (instancetype)initWithBannerView:(CRBannerView *)bannerView;
 
@@ -37,7 +37,7 @@
 
 @end
 
-@implementation CRBannerCustomEvent (Test)
+@implementation CRCustomEventBanner (Test)
 
 - (instancetype)initWithBannerView:(CRBannerView *)bannerView {
   if (self = [super init]) {
@@ -63,7 +63,7 @@ static void *DelegateAssociationKey;
 
 @end
 
-@interface CRBannerCustomEventTests : XCTestCase {
+@interface CRCustomEventBannerTests : XCTestCase {
   NSString *bannerAdUnitId;
   CGSize adUnitSize;
   NSDictionary *info;
@@ -71,7 +71,7 @@ static void *DelegateAssociationKey;
 
 @end
 
-@implementation CRBannerCustomEventTests
+@implementation CRCustomEventBannerTests
 
 - (void)setUp {
   bannerAdUnitId = @"banner adunit id";
@@ -87,7 +87,7 @@ static void *DelegateAssociationKey;
 
 - (void)testRequestWithInvalidInfo {
   NSDictionary *invalidInfo = @{@"invalidKey" : @"value"};
-  CRBannerCustomEvent *bannerCustomEvent = [[CRBannerCustomEvent alloc] init];
+  CRCustomEventBanner *bannerCustomEvent = [[CRCustomEventBanner alloc] init];
   id mockBannerCustomEventDelegate = OCMStrictProtocolMock(@protocol(MPInlineAdAdapterDelegate));
   bannerCustomEvent.delegate = mockBannerCustomEventDelegate;
   NSString *expectedErrorDescription =
@@ -105,15 +105,15 @@ static void *DelegateAssociationKey;
   CRBannerAdUnit *bannerAdUnit = [[CRBannerAdUnit alloc] initWithAdUnitId:bannerAdUnitId
                                                                      size:adUnitSize];
   id mockBannerView = OCMClassMock([CRBannerView class]);
-  CRBannerCustomEvent *bannerCustomEvent =
-      [[CRBannerCustomEvent alloc] initWithBannerView:mockBannerView];
+  CRCustomEventBanner *bannerCustomEvent =
+      [[CRCustomEventBanner alloc] initWithBannerView:mockBannerView];
   OCMExpect([mockCriteo registerCriteoPublisherId:info[@"cpId"] withAdUnits:@[ bannerAdUnit ]]);
   [bannerCustomEvent requestAdWithSize:adUnitSize adapterInfo:info];
   OCMVerifyAll(mockCriteo);
 }
 
 - (void)testBannerViewCorrect {
-  CRBannerCustomEvent *bannerCustomEvent = [[CRBannerCustomEvent alloc] init];
+  CRCustomEventBanner *bannerCustomEvent = [[CRCustomEventBanner alloc] init];
   [bannerCustomEvent requestAdWithSize:adUnitSize adapterInfo:info];
   XCTAssertEqual(bannerCustomEvent.bannerView.frame.size.width, adUnitSize.width);
   XCTAssertEqual(bannerCustomEvent.bannerView.frame.size.height, adUnitSize.height);
@@ -121,8 +121,8 @@ static void *DelegateAssociationKey;
 
 - (void)testBannerViewLoadedAndDelegateIsSet {
   id mockBannerView = OCMStrictClassMock([CRBannerView class]);
-  CRBannerCustomEvent *bannerCustomEvent =
-      [[CRBannerCustomEvent alloc] initWithBannerView:mockBannerView];
+  CRCustomEventBanner *bannerCustomEvent =
+      [[CRCustomEventBanner alloc] initWithBannerView:mockBannerView];
   OCMExpect([mockBannerView setDelegate:bannerCustomEvent]);
   OCMExpect([mockBannerView loadAd]);
   [bannerCustomEvent requestAdWithSize:adUnitSize adapterInfo:info];
@@ -132,7 +132,7 @@ static void *DelegateAssociationKey;
 - (void)testBannerViewSetMopubConsent {
   id mockCriteo = [OCMockObject partialMockForObject:[Criteo sharedCriteo]];
   id mockMopub = [OCMockObject partialMockForObject:[MoPub sharedInstance]];
-  CRBannerCustomEvent *bannerCustomEvent = [[CRBannerCustomEvent alloc] init];
+  CRCustomEventBanner *bannerCustomEvent = [[CRCustomEventBanner alloc] init];
   OCMStub([mockMopub currentConsentStatus]).andReturn(MPConsentStatusDenied);
 
   [mockCriteo setExpectationOrderMatters:YES];
@@ -148,8 +148,8 @@ static void *DelegateAssociationKey;
 
 - (void)testDelegateSuccessfulAdRequest {
   id mockBannerView = OCMClassMock([CRBannerView class]);
-  CRBannerCustomEvent *bannerCustomEvent =
-      [[CRBannerCustomEvent alloc] initWithBannerView:mockBannerView];
+  CRCustomEventBanner *bannerCustomEvent =
+      [[CRCustomEventBanner alloc] initWithBannerView:mockBannerView];
 
   id mockBannerCustomEventDelegate = OCMStrictProtocolMock(@protocol(MPInlineAdAdapterDelegate));
   bannerCustomEvent.delegate = mockBannerCustomEventDelegate;
@@ -165,8 +165,8 @@ static void *DelegateAssociationKey;
 
 - (void)testDelegateFailedAdRequest {
   id mockBannerView = OCMClassMock([CRBannerView class]);
-  CRBannerCustomEvent *bannerCustomEvent =
-      [[CRBannerCustomEvent alloc] initWithBannerView:mockBannerView];
+  CRCustomEventBanner *bannerCustomEvent =
+      [[CRCustomEventBanner alloc] initWithBannerView:mockBannerView];
   NSError *expectedCriteoError = [NSError errorWithCode:MOPUBErrorUnknown];
   NSString *errorDescription =
       [NSString stringWithFormat:@"Criteo Banner failed to load with error: %@",
@@ -188,8 +188,8 @@ static void *DelegateAssociationKey;
 
 - (void)testDelegateBannerLeaveApplication {
   id mockBannerView = OCMClassMock([CRBannerView class]);
-  CRBannerCustomEvent *bannerCustomEvent =
-      [[CRBannerCustomEvent alloc] initWithBannerView:mockBannerView];
+  CRCustomEventBanner *bannerCustomEvent =
+      [[CRCustomEventBanner alloc] initWithBannerView:mockBannerView];
 
   id mockBannerCustomEventDelegate = OCMStrictProtocolMock(@protocol(MPInlineAdAdapterDelegate));
   bannerCustomEvent.delegate = mockBannerCustomEventDelegate;

--- a/CriteoMoPubAdapter/Tests/CriteoMoPubAdapterTests/CRCustomEventInterstitialTests.m
+++ b/CriteoMoPubAdapter/Tests/CriteoMoPubAdapterTests/CRCustomEventInterstitialTests.m
@@ -1,5 +1,5 @@
 //
-//  CRInterstitialCustomEventTests.m
+//  CRCustomEventInterstitialTests.m
 //  CriteoMoPubAdapterTests
 //
 //  Copyright © 2018-2020 Criteo. All rights reserved.
@@ -18,15 +18,15 @@
 
 #import <XCTest/XCTest.h>
 #import <OCMock.h>
-#import "CRInterstitialCustomEvent.h"
+#import "CRCustomEventInterstitial.h"
 
-@interface CRInterstitialCustomEvent ()
+@interface CRCustomEventInterstitial ()
 
 @property(nonatomic, strong) CRInterstitial *interstitial;
 
 @end
 
-@interface CRInterstitialCustomEvent (Test)
+@interface CRCustomEventInterstitial (Test)
 
 @property(nonatomic, weak) id<MPFullscreenAdAdapterDelegate> delegate;
 
@@ -34,7 +34,7 @@
 
 @end
 
-@implementation CRInterstitialCustomEvent (Test)
+@implementation CRCustomEventInterstitial (Test)
 
 - (void)requestAdWithAdapterInfo:(NSDictionary *)info {
   [self requestAdWithAdapterInfo:info adMarkup:nil];
@@ -53,16 +53,16 @@ static void *DelegateAssociationKey;
 
 @end
 
-@interface CRInterstitialCustomEventTests : XCTestCase
+@interface CRCustomEventInterstitialTests : XCTestCase
 @end
 
-@implementation CRInterstitialCustomEventTests {
+@implementation CRCustomEventInterstitialTests {
   NSString *adUnitId;
   NSDictionary *info;
   NSString *publisherId;
   id mockInterstitial;
   id mockDelegate;
-  CRInterstitialCustomEvent *event;
+  CRCustomEventInterstitial *event;
 }
 
 - (void)setUp {
@@ -71,7 +71,7 @@ static void *DelegateAssociationKey;
   info = @{@"cpId" : publisherId, @"adUnitId" : adUnitId};
   mockInterstitial = OCMClassMock([CRInterstitial class]);
   mockDelegate = OCMStrictProtocolMock(@protocol(MPFullscreenAdAdapterDelegate));
-  event = [[CRInterstitialCustomEvent alloc] init];
+  event = [[CRCustomEventInterstitial alloc] init];
   event.interstitial = mockInterstitial;
   event.delegate = mockDelegate;
 }

--- a/CriteoPublisherSdk/Sources/Configuration/CR_IntegrationRegistry.m
+++ b/CriteoPublisherSdk/Sources/Configuration/CR_IntegrationRegistry.m
@@ -65,7 +65,7 @@ NSString *const NSUserDefaultsIntegrationKey = @"CRITEO_ProfileId";
 }
 
 - (BOOL)isAdMobMediationPresent {
-  return NSClassFromString(@"CRBannerCustomEvent") != nil &&
+  return NSClassFromString(@"CRCustomEventBanner") != nil &&
          NSProtocolFromString(@"GADCustomEventBanner") != nil;
 }
 


### PR DESCRIPTION
**GAM update PR 1**
- Renamed `CRBannerCustomEvent` to `CRCustomEventBanner`
- Renamed `CRInterstitialCustomEvent` to `CRCustomEventInterstitial`

The motivation for this renaming is because it's the word order typology used by `GoogleMobileAds` framework.


**Jira**: [DPP-3562](https://criteo.atlassian.net/browse/DPP-3562)